### PR TITLE
Fix structural error - should NOT have fewer than 1 items

### DIFF
--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -63,7 +63,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
 
   def cleanup_hash!(base, spec, selector)
     RSpec::OpenAPI::HashHelper.matched_paths(base, selector).each do |paths|
-      base.dig(*paths).delete('required') if base.dig(*paths)['required']&.empty?
+      base.dig(*paths).delete('required') if base.dig(*paths).is_a?(Hash) && base.dig(*paths)['required']&.empty?
       exist_in_base = !base.dig(*paths).nil?
       not_in_spec = spec.dig(*paths).nil?
       if exist_in_base && not_in_spec


### PR DESCRIPTION
First of all, the project is amazing and is serving me perfectly. I hope it continues to evolve for a long time.
Well, I found a problem when generating the openapi from the request of a `put` method. The required field is generated empty and this results in an error when reading the file as shown in the images below:

![2023-04-28_12-16](https://user-images.githubusercontent.com/4484665/235186847-f22e4676-cee1-44c7-b35d-07884623da24.png)

![2023-04-28_12-05](https://user-images.githubusercontent.com/4484665/235186277-f86181f4-d01a-4113-88c1-ed52ece4cd6c.png)

To fix the error, I simply removed the required field if it was empty.


