### PR TITLE
Add instructions for minitest triggered yaml generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ It should work with both classes inheriting from `ActionDispatch::IntegrationTes
 
 Please note that not all features present in the rspec integration work with minitest (yet). For example, custom per test case metadata is not supported. A custom `description_builder` will not work either.
 
+Run minitest with OPENAPI=1 to generate `doc/openapi.yaml` for your request specs.
+
+```bash
+$ OPENAPI=1 bundle exec rails t
+```
+
 ## Links
 
 Existing RSpec plugins which have OpenAPI integration:


### PR DESCRIPTION
Hi, I was missing the OPENAPI=1 flag for minitest. To prevent others from stumbling upon this I added the command to invoke to the readme.