### PR TITLE
Fix multiple uploaded files examples

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -195,6 +195,11 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         value[key] = v.original_filename
       elsif v.is_a?(Hash)
         adjust_params(v)
+      elsif v.is_a?(Array)
+        result = v.map do |item|
+          item.is_a?(ActionDispatch::Http::UploadedFile) ? item.original_filename : item
+        end
+        value[key] = result
       end
     end
   end

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -103,14 +103,12 @@ end
 class TablesUpdateTest < ActionDispatch::IntegrationTest
   openapi!
 
-  test 'returns a table' do
+  test 'returns a table with array' do
     png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
     QBoAAAAASUVORK5CYII='.unpack1('m')
     File.binwrite('test.png', png)
     image = Rack::Test::UploadedFile.new('test.png', 'image/png')
-    patch '/tables/1', headers: { authorization: 'k0kubun' }, params: {
-      nested: { image: image, caption: 'Some caption' },
-    }
+    patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { images: [image, image] }
     assert_response 200
   end
 end

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -103,12 +103,8 @@ end
 class TablesUpdateTest < ActionDispatch::IntegrationTest
   openapi!
 
-  test 'returns a table with array' do
-    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
-    QBoAAAAASUVORK5CYII='.unpack1('m')
-    File.binwrite('test.png', png)
-    image = Rack::Test::UploadedFile.new('test.png', 'image/png')
-    patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { images: [image, image] }
+  test 'returns a table' do
+    patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
     assert_response 200
   end
 end
@@ -137,6 +133,33 @@ class ImageTest < ActionDispatch::IntegrationTest
 
   test 'can return an object with an attribute of empty array' do
     get '/images'
+    assert_response 200
+  end
+
+  test 'returns a image payload with upload' do
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+    QBoAAAAASUVORK5CYII='.unpack1('m')
+    File.binwrite('test.png', png)
+    image = Rack::Test::UploadedFile.new('test.png', 'image/png')
+    post '/images/upload', params: { image: image }
+    assert_response 200
+  end
+
+  test 'returns a image payload with upload nested' do
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+    QBoAAAAASUVORK5CYII='.unpack1('m')
+    File.binwrite('test.png', png)
+    image = Rack::Test::UploadedFile.new('test.png', 'image/png')
+    post '/images/upload_nested', params: { nested_image: { image: image, caption: 'Some caption' } }
+    assert_response 200
+  end
+
+  test 'returns a image payload with upload multiple' do
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+    QBoAAAAASUVORK5CYII='.unpack1('m')
+    File.binwrite('test.png', png)
+    image = Rack::Test::UploadedFile.new('test.png', 'image/png')
+    post '/images/upload_multiple', params: { images: [image, image] }
     assert_response 200
   end
 end

--- a/spec/rails/app/controllers/images_controller.rb
+++ b/spec/rails/app/controllers/images_controller.rb
@@ -1,8 +1,6 @@
 class ImagesController < ApplicationController
   def show
-    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
-    QBoAAAAASUVORK5CYII='.unpack('m').first
-    send_data png, type: 'image/png', disposition: 'inline'
+    send_image
   end
 
   def index
@@ -13,5 +11,25 @@ class ImagesController < ApplicationController
       },
     ]
     render json: list
+  end
+
+  def upload
+    send_image
+  end
+
+  def upload_nested
+    send_image
+  end
+
+  def upload_multiple
+    send_image
+  end
+
+  private
+
+  def send_image
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+    QBoAAAAASUVORK5CYII='.unpack('m').first
+    send_data png, type: 'image/png', disposition: 'inline'
   end
 end

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -3,7 +3,13 @@ Rails.application.routes.draw do
 
   defaults format: 'json' do
     resources :tables, only: [:index, :show, :create, :update, :destroy]
-    resources :images, only: [:index, :show]
+    resources :images, only: [:index, :show] do
+      collection do
+        post 'upload'
+        post 'upload_nested'
+        post 'upload_multiple'
+      end
+    end
     resources :users,  only: [:show, :create]
 
     get '/test_block' => ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -455,50 +455,27 @@
         ],
         "requestBody": {
           "content": {
-            "multipart/form-data": {
+            "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "nested": {
-                    "type": "object",
-                    "properties": {
-                      "image": {
-                        "type": "string",
-                        "format": "binary"
-                      },
-                      "caption": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "image",
-                      "caption"
-                    ]
-                  },
-                  "images": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "binary"
-                    }
+                  "name": {
+                    "type": "string"
                   }
                 },
                 "required": [
-                  "images"
+                  "name"
                 ]
               },
               "example": {
-                "images": [
-                  "test.png",
-                  "test.png"
-                ]
+                "name": "test"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "returns a table with array",
+            "description": "returns a table",
             "content": {
               "application/json": {
                 "schema": {
@@ -799,6 +776,153 @@
                     ]
                   }
                 ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload_multiple": {
+      "post": {
+        "summary": "upload_multiple",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                },
+                "required": [
+                  "images"
+                ]
+              },
+              "example": {
+                "images": [
+                  "test.png",
+                  "test.png"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload multiple",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload_nested": {
+      "post": {
+        "summary": "upload_nested",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nested_image": {
+                    "type": "object",
+                    "properties": {
+                      "image": {
+                        "type": "string",
+                        "format": "binary"
+                      },
+                      "caption": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "caption"
+                    ]
+                  }
+                },
+                "required": [
+                  "nested_image"
+                ]
+              },
+              "example": {
+                "nested_image": {
+                  "image": "test.png",
+                  "caption": "Some caption"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload nested",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload": {
+      "post": {
+        "summary": "upload",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "image"
+                ]
+              },
+              "example": {
+                "image": "test.png"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           }

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -474,24 +474,31 @@
                       "image",
                       "caption"
                     ]
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
                   }
                 },
                 "required": [
-                  "nested"
+                  "images"
                 ]
               },
               "example": {
-                "nested": {
-                  "image": "test.png",
-                  "caption": "Some caption"
-                }
+                "images": [
+                  "test.png",
+                  "test.png"
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "returns a table",
+            "description": "returns a table with array",
             "content": {
               "application/json": {
                 "schema": {

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -311,35 +311,19 @@ paths:
         example: 1
       requestBody:
         content:
-          multipart/form-data:
+          application/x-www-form-urlencoded:
             schema:
               type: object
               properties:
-                nested:
-                  type: object
-                  properties:
-                    image:
-                      type: string
-                      format: binary
-                    caption:
-                      type: string
-                  required:
-                  - image
-                  - caption
-                images:
-                  type: array
-                  items:
-                    type: string
-                    format: binary
+                name:
+                  type: string
               required:
-              - images
+              - name
             example:
-              images:
-              - test.png
-              - test.png
+              name: test
       responses:
         '200':
-          description: returns a table with array
+          description: returns a table
           content:
             application/json:
               schema:
@@ -538,3 +522,95 @@ paths:
               example:
               - name: file.png
                 tags: []
+  "/images/upload_multiple":
+    post:
+      summary: upload_multiple
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+              required:
+              - images
+            example:
+              images:
+              - test.png
+              - test.png
+      responses:
+        '200':
+          description: returns a image payload with upload multiple
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/upload":
+    post:
+      summary: upload
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+              required:
+              - image
+            example:
+              image: test.png
+      responses:
+        '200':
+          description: returns a image payload with upload
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/upload_nested":
+    post:
+      summary: upload_nested
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                nested_image:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      format: binary
+                    caption:
+                      type: string
+                  required:
+                  - image
+                  - caption
+              required:
+              - nested_image
+            example:
+              nested_image:
+                image: test.png
+                caption: Some caption
+      responses:
+        '200':
+          description: returns a image payload with upload nested
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -326,15 +326,20 @@ paths:
                   required:
                   - image
                   - caption
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
               required:
-              - nested
+              - images
             example:
-              nested:
-                image: test.png
-                caption: Some caption
+              images:
+              - test.png
+              - test.png
       responses:
         '200':
-          description: returns a table
+          description: returns a table with array
           content:
             application/json:
               schema:

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -84,15 +84,8 @@ RSpec.describe 'Tables', type: :request do
   end
 
   describe '#update' do
-    before do
-      png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
-      QBoAAAAASUVORK5CYII='.unpack1('m')
-      File.binwrite('test.png', png)
-    end
-    let(:image) { Rack::Test::UploadedFile.new('test.png', 'image/png') }
-
-    it 'returns a table with array' do
-      patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { images: [image, image] }
+    it 'returns a table' do
+      patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
       expect(response.status).to eq(200)
     end
   end
@@ -121,6 +114,48 @@ RSpec.describe 'Images', type: :request do
   describe '#index' do
     it 'can return an object with an attribute of empty array' do
       get '/images'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#upload' do
+    before do
+      png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+      QBoAAAAASUVORK5CYII='.unpack1('m')
+      File.binwrite('test.png', png)
+    end
+    let(:image) { Rack::Test::UploadedFile.new('test.png', 'image/png') }
+
+    it 'returns a image payload with upload' do
+      post '/images/upload', params: { image: image }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#upload_nested' do
+    before do
+      png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+      QBoAAAAASUVORK5CYII='.unpack1('m')
+      File.binwrite('test.png', png)
+    end
+    let(:image) { Rack::Test::UploadedFile.new('test.png', 'image/png') }
+
+    it 'returns a image payload with upload nested' do
+      post '/images/upload_nested', params: { nested_image: { image: image, caption: 'Some caption' } }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#upload_multiple' do
+    before do
+      png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+      QBoAAAAASUVORK5CYII='.unpack1('m')
+      File.binwrite('test.png', png)
+    end
+    let(:image) { Rack::Test::UploadedFile.new('test.png', 'image/png') }
+
+    it 'returns a image payload with upload multiple' do
+      post '/images/upload_multiple', params: { images: [image, image] }
       expect(response.status).to eq(200)
     end
   end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -90,10 +90,9 @@ RSpec.describe 'Tables', type: :request do
       File.binwrite('test.png', png)
     end
     let(:image) { Rack::Test::UploadedFile.new('test.png', 'image/png') }
-    it 'returns a table' do
-      patch '/tables/1', headers: { authorization: 'k0kubun' }, params: {
-        nested: { image: image, caption: 'Some caption' },
-      }
+
+    it 'returns a table with array' do
+      patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { images: [image, image] }
       expect(response.status).to eq(200)
     end
   end


### PR DESCRIPTION
Adjust the multiple example parameters.

I get this linting error with an endpoint that receives an uploaded file: unknown tag !<!ruby/object:File>

The spec is structured in this way:

```
  describe "POST /api/v1/my_pages" do
    subject do
      post api_v1_my_pages_path(my_page), params: params, headers: default_headers
    end

    let!(:user) { create(:user) }
    let!(:my_page) { create(:my_page) }
    let(:params) { { example: { title: 'test', images: [fixture_file_upload('/images/Logo.png')] } } }

      it 'success' do
        sign_in user
        expect(response).to have_http_status(:created)
      end
```

I have added the fix for this issue by speculating that the cause lies in the schema_builder.rb file's failure to handle cases where image is sent as an array.