### PR TITLE
Update schema_cleaner.rb

### DIFF
--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -47,7 +47,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     paths_to_objects.each do |path|
       parent = base.dig(*path.take(path.length - 1))
       # "required" array  must not be present if empty
-      parent.delete('required') if parent['required'].empty?
+      parent.delete('required') if parent['required']&.empty?
     end
   end
 

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -47,7 +47,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     paths_to_objects.each do |path|
       parent = base.dig(*path.take(path.length - 1))
       # "required" array  must not be present if empty
-      parent.delete('required') if parent['required']&.empty?
+      parent.delete('required') if parent['required'] && parent['required'].empty?
     end
   end
 


### PR DESCRIPTION
```ruby
    45|       *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, 'paths', 'properties'),
    46|     ]
    47|     paths_to_objects.each do |path|
    48|       parent = base.dig(*path.take(path.length - 1))
    49|       # "required" array  must not be present if empty
=>  50|       debugger unless parent['required']
    51|       parent.delete('required') if parent['required'].empty?
    52|     end
    53|   end
    54| 
=>#0    block {|path=["paths", "/reviewer_admin/api/questions/...|} in cleanup_empty_required_array! at /usr/local/bundle/gems/rspec-openapi-0.8.1/lib/rspec/openapi/schema_cleaner.rb:50
  #1    [C] Array#each at /usr/local/bundle/gems/rspec-openapi-0.8.1/lib/rspec/openapi/schema_cleaner.rb:47
  # and 23 frames (use `bt' command for all frames)
(rdbg) parent
{"type"=>"object", "properties"=>{}}
(ruby) parent['required']
nil
(ruby) parent['required'].empty?
eval error: undefined method `empty?' for nil:NilClass
```