### PR TITLE
fix: schema cleaner parent['required'] may be nil

### DIFF
--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -47,7 +47,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     paths_to_objects.each do |path|
       parent = base.dig(*path.take(path.length - 1))
       # "required" array  must not be present if empty
-      parent.delete('required') if parent['required'].empty?
+      parent.delete('required') if parent['required']&.empty?
     end
   end
 


### PR DESCRIPTION
We had to patch the schema cleaner in our app since it was raising a NoMethodError

```ruby
require "rspec/openapi"
require "rspec/openapi/schema_cleaner"
RSpec::OpenAPI::SchemaCleaner # ensure this is loaded # rubocop:todo Lint/Void
class << RSpec::OpenAPI::SchemaCleaner
  def cleanup_empty_required_array!(base)
    paths_to_objects = [
      *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, "components.schemas", "properties"),
      *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, "paths", "properties"),
    ]
    paths_to_objects.each do |path|
      parent = base.dig(*path.take(path.length - 1))
      # "required" array  must not be present if empty
      # parent.delete('required') if parent['required'].empty?
      # NOTE(BF): hack around schema error
      # NoMethodError:
      #   undefined method `empty?' for nil:NilClass
      #
      #   parent.delete('required') if parent['required'].empty?
      #                                                  ^^^^^^^
      parent.delete("required") if parent["required"] && parent["required"].empty?
    end
  end
end
```