### PR TITLE
ci: Fix coverage collection due to SimpleCov load timing

### DIFF
--- a/.simplecov_spawn.rb
+++ b/.simplecov_spawn.rb
@@ -7,9 +7,9 @@ unless ENV['COVERAGE'] && ENV['COVERAGE'].empty?
   SimpleCov.command_name 'spawn'
   SimpleCov.at_fork.call(Process.pid)
   SimpleCov.formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::CoberturaFormatter,
-  ])
-  SimpleCov.start do |pid|
-    add_filter "/spec/"
+                                                                 SimpleCov::Formatter::CoberturaFormatter,
+                                                               ])
+  SimpleCov.start do
+    add_filter '/spec/'
   end
 end

--- a/.simplecov_spawn.rb
+++ b/.simplecov_spawn.rb
@@ -6,6 +6,10 @@ unless ENV['COVERAGE'] && ENV['COVERAGE'].empty?
 
   SimpleCov.command_name 'spawn'
   SimpleCov.at_fork.call(Process.pid)
-  SimpleCov.formatter SimpleCov::Formatter::CoberturaFormatter
-  SimpleCov.start
+  SimpleCov.formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::CoberturaFormatter,
+  ])
+  SimpleCov.start do |pid|
+    add_filter "/spec/"
+  end
 end

--- a/scripts/rspec
+++ b/scripts/rspec
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+# (The MIT License)
+# Copyright (c) 2012 Chad Humphries, David Chelimsky, Myron Marston
+# Copyright (c) 2009 Chad Humphries, David Chelimsky
+# Copyright (c) 2006 David Chelimsky, The RSpec Development Team
+# Copyright (c) 2005 Steven Baker
+
+require 'rspec/core'
+RSpec::Core::Runner.invoke

--- a/scripts/rspec
+++ b/scripts/rspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # (The MIT License)
 # Copyright (c) 2012 Chad Humphries, David Chelimsky, Myron Marston

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -32,7 +32,7 @@ begin
   old_verbose = $VERBOSE
   $VERBOSE = false
 
-  unless ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
+  if ENV['COVERAGE'] && ENV['COVERAGE'].empty? && RUBY_VERSION >= '1.9.3'
     require 'simplecov'
 
     SimpleCov.start do

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # (The MIT License)
 # Copyright (c) 2012 Chad Humphries, David Chelimsky, Myron Marston

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -11,14 +11,14 @@ $VERBOSE = true
 
 # So our "did they run the rspec command?" detection logic thinks
 # that we run `rspec`.
-$0 = "rspec"
+$0 = 'rspec'
 
 # This is necessary for when `--standalone` is being used.
-$:.unshift File.expand_path '../../bundle', __FILE__
+$:.unshift File.expand_path '../bundle', __dir__
 
 # For the travis build we put the bundle directory up a directory
 # so it can be shared among the repos for faster bundle installs.
-$:.unshift File.expand_path '../../../bundle', __FILE__
+$:.unshift File.expand_path '../../bundle', __dir__
 
 require 'bundler/setup'
 
@@ -28,15 +28,16 @@ require 'bundler/setup'
 # first loads simplecov, and then loads rspec.
 begin
   # Simplecov emits some ruby warnings when loaded, so silence them.
-  old_verbose, $VERBOSE = $VERBOSE, false
+  old_verbose = $VERBOSE
+  $VERBOSE = false
 
   unless ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
     require 'simplecov'
 
     SimpleCov.start do
-      add_filter "./bundle/"
-      add_filter "./tmp/"
-      add_filter "./spec/"
+      add_filter './bundle/'
+      add_filter './tmp/'
+      add_filter './spec/'
       minimum_coverage(RUBY_PLATFORM == 'java' ? 94 : 97)
     end
   end
@@ -45,4 +46,4 @@ ensure
   $VERBOSE = old_verbose
 end
 
-load File.expand_path("../rspec", __FILE__)
+load File.expand_path('rspec', __dir__)

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -32,7 +32,7 @@ begin
   old_verbose = $VERBOSE
   $VERBOSE = false
 
-  if ENV['COVERAGE'] && ENV['COVERAGE'].empty? && RUBY_VERSION >= '1.9.3'
+  unless ENV['COVERAGE'] && ENV['COVERAGE'].empty? || RUBY_VERSION < '1.9.3'
     require 'simplecov'
 
     SimpleCov.start do

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+
+# (The MIT License)
+# Copyright (c) 2012 Chad Humphries, David Chelimsky, Myron Marston
+# Copyright (c) 2009 Chad Humphries, David Chelimsky
+# Copyright (c) 2006 David Chelimsky, The RSpec Development Team
+# Copyright (c) 2005 Steven Baker
+
+# Turn on verbose to make sure we not generating any ruby warning
+$VERBOSE = true
+
+# So our "did they run the rspec command?" detection logic thinks
+# that we run `rspec`.
+$0 = "rspec"
+
+# This is necessary for when `--standalone` is being used.
+$:.unshift File.expand_path '../../bundle', __FILE__
+
+# For the travis build we put the bundle directory up a directory
+# so it can be shared among the repos for faster bundle installs.
+$:.unshift File.expand_path '../../../bundle', __FILE__
+
+require 'bundler/setup'
+
+# To use simplecov while running rspec-core's test suite, we must
+# load simplecov _before_ loading any of rspec-core's files.
+# So, this executable exists purely as a wrapper script that
+# first loads simplecov, and then loads rspec.
+begin
+  # Simplecov emits some ruby warnings when loaded, so silence them.
+  old_verbose, $VERBOSE = $VERBOSE, false
+
+  unless ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
+    require 'simplecov'
+
+    SimpleCov.start do
+      add_filter "./bundle/"
+      add_filter "./tmp/"
+      add_filter "./spec/"
+      minimum_coverage(RUBY_PLATFORM == 'java' ? 94 : 97)
+    end
+  end
+rescue LoadError
+ensure
+  $VERBOSE = old_verbose
+end
+
+load File.expand_path("../rspec", __FILE__)

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -113,7 +113,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample: 
+                null_sample:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -207,7 +207,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample: 
+                null_sample:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -272,7 +272,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample: 
+                null_sample:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -374,7 +374,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample: 
+                null_sample:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -438,7 +438,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample: 
+                null_sample:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,10 @@ module SpecHelper
   end
 
   def run_tests(*args, command:, openapi: false, output: :yaml)
-    env = { 'OPENAPI' => ('1' if openapi), 'OPENAPI_OUTPUT' => output.to_s }.compact
+    env = {
+      'OPENAPI' => ('1' if openapi),
+      'OPENAPI_OUTPUT' => output.to_s,
+    }.compact
     Bundler.public_send(Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env) do
       Dir.chdir(repo_root) do
         assert_run env, 'bundle', 'exec', command, '-r./.simplecov_spawn', *args
@@ -23,7 +26,7 @@ module SpecHelper
   end
 
   def rspec(*args, openapi: false, output: :yaml)
-    run_tests(*args, command: 'rspec', openapi: openapi, output: output)
+    run_tests(*args, command: 'scripts/rspec_with_simplecov', openapi: openapi, output: output)
   end
 
   def minitest(*args, openapi: false, output: :yaml)


### PR DESCRIPTION
To collect coverage, it turned out that SimpleCov must be loaded before RSpec.
This PR borrows the workaround in rspec-core: https://github.com/rspec/rspec-core/blob/81589709e88db1ec2537faee3a7f4a43c7d9aac1/script/rspec_with_simplecov