### PR TITLE
Don't dump records into temporary file

### DIFF
--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -15,7 +15,6 @@ class RSpec::OpenAPI::ResultRecorder
         RSpec::OpenAPI::SchemaMerger.merge!(spec, schema)
         new_from_zero = {}
         records.each do |record|
-          File.open('/tmp/records', 'a') { |f| f.puts record.to_yaml }
           begin
             record_schema = RSpec::OpenAPI::SchemaBuilder.build(record)
             RSpec::OpenAPI::SchemaMerger.merge!(spec, record_schema)


### PR DESCRIPTION
I browsed the source code the other day and found this statement. As it is referenced nowhere else in the code, I assume it was used for debugging purposes when implementing the Minitest support and is therefore no longer necessary.