### PR TITLE
Prepend `openapi!` in any case

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -10,10 +10,8 @@ require 'rspec/openapi/schema_file'
 require 'rspec/openapi/schema_merger'
 require 'rspec/openapi/schema_cleaner'
 
-if ENV['OPENAPI']
-  require 'rspec/openapi/minitest_hooks'
-  require 'rspec/openapi/rspec_hooks'
-end
+require 'rspec/openapi/minitest_hooks' if Object.const_defined?('Minitest')
+require 'rspec/openapi/rspec_hooks' if ENV['OPENAPI'] && Object.const_defined?('RSpec')
 
 module RSpec::OpenAPI
   @path = 'doc/openapi.yaml'

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -4,9 +4,8 @@ ENV['TZ'] ||= 'UTC'
 ENV['RAILS_ENV'] ||= 'test'
 ENV['OPENAPI_OUTPUT'] ||= 'yaml'
 
-require File.expand_path('../rails/config/environment', __dir__)
-
 require 'minitest/autorun'
+require File.expand_path('../rails/config/environment', __dir__)
 
 RSpec::OpenAPI.request_headers = %w[X-Authorization-Token]
 RSpec::OpenAPI.response_headers = %w[X-Cursor]

--- a/spec/integration_tests/roda_test.rb
+++ b/spec/integration_tests/roda_test.rb
@@ -3,8 +3,8 @@
 require_relative '../roda/roda_app'
 require 'json'
 require 'rack/test'
-require 'rspec/openapi'
 require 'minitest/autorun'
+require 'rspec/openapi'
 
 ENV['OPENAPI_OUTPUT'] ||= 'yaml'
 

--- a/spec/minitest/rack_test_spec.rb
+++ b/spec/minitest/rack_test_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe 'rack-test minitest' do
       expect(new_yaml).to eq org_yaml
     end
   end
+
+  describe 'with disabled OpenAPI generation' do
+    it 'can run tests' do
+      minitest 'spec/integration_tests/roda_test.rb'
+    end
+  end
 end

--- a/spec/minitest/rails_spec.rb
+++ b/spec/minitest/rails_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe 'rails integration minitest' do
       expect(new_yaml).to eq org_yaml
     end
   end
+
+  describe 'with disabled OpenAPI generation' do
+    it 'can run tests' do
+      minitest 'spec/integration_tests/rails_test.rb'
+    end
+  end
 end


### PR DESCRIPTION
If you run tests with Minitest at the moment, but without the environment variable `OPENAPI`, you are greeted with an error message.

```
undefined method `openapi!' for Api::V0::SomeControllerTest:Class (NoMethodError)`
```

This is because the current code adds the `openapi!` method only if `OPENAPI` environment variable is set.

This commit modifies the loading logic, always requiring the `minitest` hooks class to be loaded if `Minitest` constant is defined, to avoid issues with RSpec. Then, the `openapi?` and `openapi!` methods are always prepended to `Minitest::Test`, while the modified `run` method and the `after_run` hook are only activated when `OPENAPI` environment variable is set.