### PR TITLE
added operationId to metadata of request specs

### DIFF
--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -11,6 +11,7 @@ RSpec::OpenAPI::Record = Struct.new(
   :request_headers,       # @param [Array]  - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
   :summary,               # @param [String]  - "v1/statuses #show"
   :tags,                  # @param [Array]   - ["Status"]
+  :operation_id,          # @param [String]   - "request-1234"
   :description,           # @param [String]  - "returns a status"
   :security,              # @param [Array]  - [{securityScheme1: []}]
   :status,                # @param [Integer] - 200

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -11,7 +11,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     request, response = extract_request_response(context)
     return if request.nil?
 
-    path, summary, tags, required_request_params, raw_path_params, description, security =
+    path, summary, tags, operation_id, required_request_params, raw_path_params, description, security =
       extract_request_attributes(request, example)
 
     request_headers, response_headers = extract_headers(request, response)
@@ -27,6 +27,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       request_headers: request_headers,
       summary: summary,
       tags: tags,
+      operation_id: operation_id,
       description: description,
       security: security,
       status: response.status,
@@ -63,6 +64,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     metadata = example.metadata[:openapi] || {}
     summary = metadata[:summary]
     tags = metadata[:tags]
+    operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
@@ -78,7 +80,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       raw_path_params = raw_path_params.slice(*(raw_path_params.keys - %i[controller action format]))
     end
     summary ||= "#{request.method} #{path}"
-    [path, summary, tags, required_request_params, raw_path_params, description, security]
+    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security]
   end
 
   def extract_request_response(context)

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -27,6 +27,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
           record.http_method.downcase => {
             summary: record.summary,
             tags: record.tags,
+            operationId: record.operation_id,
             security: record.security,
             parameters: build_parameters(record),
             requestBody: build_request_body(record),

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -86,6 +86,7 @@ paths:
                   - message
               example:
                 message: Unauthorized
+      operationId: table-index
   "/tables/{id}":
     get:
       summary: show

--- a/spec/requests/rails_smart_merge_spec.rb
+++ b/spec/requests/rails_smart_merge_spec.rb
@@ -36,7 +36,7 @@ RSpec::OpenAPI.info = {
 
 # Small subset of `rails_spec.rb` with slight changes
 RSpec.describe 'Tables', type: :request do
-  describe '#index', openapi: { required_request_params: 'show_columns' } do
+  describe '#index', openapi: { required_request_params: 'show_columns', operation_id: 'table-index' } do
     context it 'returns a list of tables' do
       it 'with flat query parameters' do
         # These new params replace them in old spec


### PR DESCRIPTION
Added a change to allow users to add operationId to the metadata of request specs. There have been requests to make the  OpenAPI spec require operationId for many reasons. Here is an example: https://github.com/OAI/OpenAPI-Specification/issues/1907. 

If a user adds `operation-id` to the metadata of a request spec, it will be added to the path section of the schema.  

First time contributor and I struggled to figure out where to add a test for this feature. Let me know if there is a place where you would like to see a spec for this.

