### PR TITLE
Add ability to define custom summary and tags builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,12 @@ EOS
 RSpec::OpenAPI.description_builder = -> (example) { example.description }
 
 # Generate a custom summary, given an RSpec example
-RSpec::OpenAPI.summary_builder = -> (example) { example.metadata[:summary] }
+# This example uses the summary from the example_group.
+RSpec::OpenAPI.summary_builder = ->(example) { example.metadata.dig(:example_group, :openapi, :summary) }
 
 # Generate a custom tags, given an RSpec example
-RSpec::OpenAPI.tags_builder = -> (example) { example.metadata[:tags] }
+# This example uses the tags from the parent_example_group
+RSpec::OpenAPI.tags_builder = -> (example) { example.metadata.dig(:example_group, :parent_example_group, :openapi, :tags) }
 
 # Change the example type(s) that will generate schema
 RSpec::OpenAPI.example_types = %i[request]

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ EOS
 # Generate a custom description, given an RSpec example
 RSpec::OpenAPI.description_builder = -> (example) { example.description }
 
+# Generate a custom summary, given an RSpec example
+RSpec::OpenAPI.summary_builder = -> (example) { example.metadata[:summary] }
+
+# Generate a custom tags, given an RSpec example
+RSpec::OpenAPI.tags_builder = -> (example) { example.metadata[:tags] }
+
 # Change the example type(s) that will generate schema
 RSpec::OpenAPI.example_types = %i[request]
 

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -19,6 +19,8 @@ module RSpec::OpenAPI
   @comment = nil
   @enable_example = true
   @description_builder = ->(example) { example.description }
+  @summary_builder = ->(example) { example.metadata[:summary] }
+  @tags_builder = ->(example) { example.metadata[:tags] }
   @info = {}
   @application_version = '1.0.0'
   @request_headers = []
@@ -35,6 +37,8 @@ module RSpec::OpenAPI
                   :comment,
                   :enable_example,
                   :description_builder,
+                  :summary_builder,
+                  :tags_builder,
                   :info,
                   :application_version,
                   :request_headers,

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -62,8 +62,8 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
 
   def extract_request_attributes(request, example)
     metadata = example.metadata[:openapi] || {}
-    summary = metadata[:summary]
-    tags = metadata[:tags]
+    summary = metadata[:summary] || RSpec::OpenAPI.summary_builder.call(example)
+    tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
     security = metadata[:security]


### PR DESCRIPTION
Love this project! We use it at my company for automated documentation (using `widdershins` to take the generated OpenAPI spec and create nice Slate docs). So thank you!

We'd love to have some control over how we decide what the summary and tags are for a given example. 

For our use case, we want to be able to define tags on the parent example and have that applied to all the child examples rather than having to define them on every example.

I followed the existing pattern in the repo for custom descriptions so that any custom scenario could be supported. 