### PR TITLE
Merge parameter data to preserve description in manually edited Openapi spec

### DIFF
--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -142,6 +142,7 @@
             "name": "filter[name]",
             "in": "query",
             "required": false,
+            "description": "Filter by name",
             "schema": {
               "type": "object",
               "properties": {

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -29,6 +29,7 @@ paths:
       - name: filter[name]
         in: query
         required: false
+        description: Filter by name
         schema:
           type: object
           properties:


### PR DESCRIPTION
Resolves #144 

In the [issue comment](https://github.com/exoego/rspec-openapi/issues/144#issuecomment-1778635427), I saw that we expect to be able to add/edit parameter descriptions and have them be preserved.

From my testing, it looks like that's not happening.

This is a small change that should keep the unique behavior on parameter `name` and `in` while preserving `description` if someone manually added it to the generated properties.