### PR TITLE
Add ability to configure which path params to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ RSpec::OpenAPI.description_builder = -> (example) { example.description }
 
 # Change the example type(s) that will generate schema
 RSpec::OpenAPI.example_types = %i[request]
+
+# Configure which path params to ignore
+# :controller and :action always exist. :format is added when routes is configured as such.
+RSpec::OpenAPI.ignored_path_params = %i[controller action format]
+
 ```
 
 ### Can I use rspec-openapi with `$ref` to minimize duplication of schema?

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -26,6 +26,7 @@ module RSpec::OpenAPI
   @example_types = %i[request]
   @response_headers = []
   @path_records = Hash.new { |h, k| h[k] = [] }
+  @ignored_path_params = %i[controller action format]
 
   class << self
     attr_accessor :path,
@@ -39,6 +40,7 @@ module RSpec::OpenAPI
                   :security_schemes,
                   :example_types,
                   :response_headers,
-                  :path_records
+                  :path_records,
+                  :ignored_path_params
   end
 end

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -83,7 +83,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       tags ||= [route.requirements[:controller]&.classify].compact
       # :controller and :action always exist. :format is added when routes is configured as such.
       # TODO: Use .except(:controller, :action, :format) when we drop support for Ruby 2.x
-      raw_path_params = raw_path_params.slice(*(raw_path_params.keys - %i[controller action format]))
+      raw_path_params = raw_path_params.slice(*(raw_path_params.keys - RSpec::OpenAPI.ignored_path_params))
     end
     summary ||= "#{request.method} #{path}"
     [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security]


### PR DESCRIPTION
It would be nice to be able to configure which path params to ignore. For example, sometimes it would be nice to remove path and subdomain.

By default, the configuration hasn't changed but this adds the ability to change it if you need more flexibility.