### PR TITLE
Setup Dependabot to update github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "chore"


### PR DESCRIPTION
Actions used in this repo are quite outdated (running on Node.js 12).