### PR TITLE
Sort paths lexicographically so the order of paths is more stable and predictable

### DIFF
--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -26,6 +26,7 @@ class RSpec::OpenAPI::ResultRecorder
         RSpec::OpenAPI::SchemaCleaner.cleanup!(spec, new_from_zero)
         RSpec::OpenAPI::ComponentsUpdater.update!(spec, new_from_zero)
         RSpec::OpenAPI::SchemaCleaner.cleanup_empty_required_array!(spec)
+        RSpec::OpenAPI::SchemaCleaner.sort_paths!(spec)
       end
     end
   end

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -51,6 +51,13 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     end
   end
 
+  # Sort "paths" lexicographically to make the order more predictable
+  #
+  # @param [Hash]   #
+  def sort_paths!(spec)
+    spec['paths'] = spec['paths']&.entries&.sort_by! { |path, _| path }.to_h
+  end
+
   private
 
   def cleanup_array!(base, spec, selector, fields_for_identity = [])

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -15,6 +15,332 @@
     }
   ],
   "paths": {
+    "/images": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Image"
+        ],
+        "responses": {
+          "200": {
+            "description": "can return an object with an attribute of empty array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                        }
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "tags"
+                    ]
+                  }
+                },
+                "example": [
+                  {
+                    "name": "file.png",
+                    "tags": [
+
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload": {
+      "post": {
+        "summary": "upload",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "image"
+                ]
+              },
+              "example": {
+                "image": "test.png"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload_multiple": {
+      "post": {
+        "summary": "upload_multiple",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                },
+                "required": [
+                  "images"
+                ]
+              },
+              "example": {
+                "images": [
+                  "test.png",
+                  "test.png"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload multiple",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload_multiple_nested": {
+      "post": {
+        "summary": "upload_multiple_nested",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "image": {
+                          "type": "string",
+                          "format": "binary"
+                        }
+                      },
+                      "required": [
+                        "image"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "images"
+                ]
+              },
+              "example": {
+                "images": [
+                  {
+                    "image": "test.png"
+                  },
+                  {
+                    "image": "test.png"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload multiple nested",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/upload_nested": {
+      "post": {
+        "summary": "upload_nested",
+        "tags": [
+          "Image"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nested_image": {
+                    "type": "object",
+                    "properties": {
+                      "image": {
+                        "type": "string",
+                        "format": "binary"
+                      },
+                      "caption": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "caption"
+                    ]
+                  }
+                },
+                "required": [
+                  "nested_image"
+                ]
+              },
+              "example": {
+                "nested_image": {
+                  "image": "test.png",
+                  "caption": "Some caption"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns a image payload with upload nested",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/images/{id}": {
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Image"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns a image payload",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/my_engine/eng_route": {
+      "get": {
+        "summary": "GET /my_engine/eng_route",
+        "tags": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "returns some content from the engine",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "AN ENGINE TEST"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/my_engine/test": {
+      "get": {
+        "summary": "GET /my_engine/test",
+        "tags": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "returns the block content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "ANOTHER TEST"
+              }
+            }
+          }
+        }
+      }
+    },
     "/tables": {
       "get": {
         "summary": "index",
@@ -668,38 +994,6 @@
         }
       }
     },
-    "/images/{id}": {
-      "get": {
-        "summary": "show",
-        "tags": [
-          "Image"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            },
-            "example": 1
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "returns a image payload",
-            "content": {
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/test_block": {
       "get": {
         "summary": "GET /test_block",
@@ -715,300 +1009,6 @@
                   "type": "string"
                 },
                 "example": "A TEST"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/my_engine/eng_route": {
-      "get": {
-        "summary": "GET /my_engine/eng_route",
-        "tags": [
-
-        ],
-        "responses": {
-          "200": {
-            "description": "returns some content from the engine",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                },
-                "example": "AN ENGINE TEST"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/my_engine/test": {
-      "get": {
-        "summary": "GET /my_engine/test",
-        "tags": [
-
-        ],
-        "responses": {
-          "200": {
-            "description": "returns the block content",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                },
-                "example": "ANOTHER TEST"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/images": {
-      "get": {
-        "summary": "index",
-        "tags": [
-          "Image"
-        ],
-        "responses": {
-          "200": {
-            "description": "can return an object with an attribute of empty array",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "tags": {
-                        "type": "array",
-                        "items": {
-                        }
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "tags"
-                    ]
-                  }
-                },
-                "example": [
-                  {
-                    "name": "file.png",
-                    "tags": [
-
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/images/upload_nested": {
-      "post": {
-        "summary": "upload_nested",
-        "tags": [
-          "Image"
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "nested_image": {
-                    "type": "object",
-                    "properties": {
-                      "image": {
-                        "type": "string",
-                        "format": "binary"
-                      },
-                      "caption": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "image",
-                      "caption"
-                    ]
-                  }
-                },
-                "required": [
-                  "nested_image"
-                ]
-              },
-              "example": {
-                "nested_image": {
-                  "image": "test.png",
-                  "caption": "Some caption"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "returns a image payload with upload nested",
-            "content": {
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/images/upload": {
-      "post": {
-        "summary": "upload",
-        "tags": [
-          "Image"
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "image": {
-                    "type": "string",
-                    "format": "binary"
-                  }
-                },
-                "required": [
-                  "image"
-                ]
-              },
-              "example": {
-                "image": "test.png"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "returns a image payload with upload",
-            "content": {
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/images/upload_multiple_nested": {
-      "post": {
-        "summary": "upload_multiple_nested",
-        "tags": [
-          "Image"
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "images": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "image": {
-                          "type": "string",
-                          "format": "binary"
-                        }
-                      },
-                      "required": [
-                        "image"
-                      ]
-                    }
-                  }
-                },
-                "required": [
-                  "images"
-                ]
-              },
-              "example": {
-                "images": [
-                  {
-                    "image": "test.png"
-                  },
-                  {
-                    "image": "test.png"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "returns a image payload with upload multiple nested",
-            "content": {
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/images/upload_multiple": {
-      "post": {
-        "summary": "upload_multiple",
-        "tags": [
-          "Image"
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "images": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "binary"
-                    }
-                  }
-                },
-                "required": [
-                  "images"
-                ]
-              },
-              "example": {
-                "images": [
-                  "test.png",
-                  "test.png"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "returns a image payload with upload multiple",
-            "content": {
-              "image/png": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
               }
             }
           }

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -14,6 +14,203 @@ info:
 servers:
 - url: http://localhost:3000
 paths:
+  "/images":
+    get:
+      summary: index
+      tags:
+      - Image
+      responses:
+        '200':
+          description: can return an object with an attribute of empty array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    tags:
+                      type: array
+                      items: {}
+                  required:
+                  - name
+                  - tags
+              example:
+              - name: file.png
+                tags: []
+  "/images/upload":
+    post:
+      summary: upload
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+              required:
+              - image
+            example:
+              image: test.png
+      responses:
+        '200':
+          description: returns a image payload with upload
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/upload_multiple":
+    post:
+      summary: upload_multiple
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+              required:
+              - images
+            example:
+              images:
+              - test.png
+              - test.png
+      responses:
+        '200':
+          description: returns a image payload with upload multiple
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/upload_multiple_nested":
+    post:
+      summary: upload_multiple_nested
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                images:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      image:
+                        type: string
+                        format: binary
+                    required:
+                    - image
+              required:
+              - images
+            example:
+              images:
+              - image: test.png
+              - image: test.png
+      responses:
+        '200':
+          description: returns a image payload with upload multiple nested
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/upload_nested":
+    post:
+      summary: upload_nested
+      tags:
+      - Image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                nested_image:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                      format: binary
+                    caption:
+                      type: string
+                  required:
+                  - image
+                  - caption
+              required:
+              - nested_image
+            example:
+              nested_image:
+                image: test.png
+                caption: Some caption
+      responses:
+        '200':
+          description: returns a image payload with upload nested
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/images/{id}":
+    get:
+      summary: show
+      tags:
+      - Image
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 1
+      responses:
+        '200':
+          description: returns a image payload
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  "/my_engine/eng_route":
+    get:
+      summary: GET /my_engine/eng_route
+      tags: []
+      responses:
+        '200':
+          description: returns some content from the engine
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: AN ENGINE TEST
+  "/my_engine/test":
+    get:
+      summary: GET /my_engine/test
+      tags: []
+      responses:
+        '200':
+          description: returns the block content
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: ANOTHER TEST
   "/tables":
     get:
       summary: index
@@ -457,26 +654,6 @@ paths:
               - no_content
             example:
               no_content: 'true'
-  "/images/{id}":
-    get:
-      summary: show
-      tags:
-      - Image
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
-        example: 1
-      responses:
-        '200':
-          description: returns a image payload
-          content:
-            image/png:
-              schema:
-                type: string
-                format: binary
   "/test_block":
     get:
       summary: GET /test_block
@@ -489,180 +666,3 @@ paths:
               schema:
                 type: string
               example: A TEST
-  "/my_engine/eng_route":
-    get:
-      summary: GET /my_engine/eng_route
-      tags: []
-      responses:
-        '200':
-          description: returns some content from the engine
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: AN ENGINE TEST
-  "/images":
-    get:
-      summary: index
-      tags:
-      - Image
-      responses:
-        '200':
-          description: can return an object with an attribute of empty array
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    tags:
-                      type: array
-                      items: {}
-                  required:
-                  - name
-                  - tags
-              example:
-              - name: file.png
-                tags: []
-  "/my_engine/test":
-    get:
-      summary: GET /my_engine/test
-      tags: []
-      responses:
-        '200':
-          description: returns the block content
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: ANOTHER TEST
-  "/images/upload":
-    post:
-      summary: upload
-      tags:
-      - Image
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                image:
-                  type: string
-                  format: binary
-              required:
-              - image
-            example:
-              image: test.png
-      responses:
-        '200':
-          description: returns a image payload with upload
-          content:
-            image/png:
-              schema:
-                type: string
-                format: binary
-  "/images/upload_nested":
-    post:
-      summary: upload_nested
-      tags:
-      - Image
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                nested_image:
-                  type: object
-                  properties:
-                    image:
-                      type: string
-                      format: binary
-                    caption:
-                      type: string
-                  required:
-                  - image
-                  - caption
-              required:
-              - nested_image
-            example:
-              nested_image:
-                image: test.png
-                caption: Some caption
-      responses:
-        '200':
-          description: returns a image payload with upload nested
-          content:
-            image/png:
-              schema:
-                type: string
-                format: binary
-  "/images/upload_multiple_nested":
-    post:
-      summary: upload_multiple_nested
-      tags:
-      - Image
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                images:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      image:
-                        type: string
-                        format: binary
-                    required:
-                    - image
-              required:
-              - images
-            example:
-              images:
-              - image: test.png
-              - image: test.png
-      responses:
-        '200':
-          description: returns a image payload with upload multiple nested
-          content:
-            image/png:
-              schema:
-                type: string
-                format: binary
-  "/images/upload_multiple":
-    post:
-      summary: upload_multiple
-      tags:
-      - Image
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                images:
-                  type: array
-                  items:
-                    type: string
-                    format: binary
-              required:
-              - images
-            example:
-              images:
-              - test.png
-              - test.png
-      responses:
-        '200':
-          description: returns a image payload with upload multiple
-          content:
-            image/png:
-              schema:
-                type: string
-                format: binary


### PR DESCRIPTION
While working in #154, I noticed that the order or `paths` were changed unexpectedly.
More stable, predictable order will be preferrable.