### PR TITLE
Allow path-based config overrides

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -26,6 +26,7 @@ module RSpec::OpenAPI
   @example_types = %i[request]
   @response_headers = []
   @path_records = Hash.new { |h, k| h[k] = [] }
+  @config_filename = 'rspec_openapi.rb'
 
   class << self
     attr_accessor :path,
@@ -39,6 +40,7 @@ module RSpec::OpenAPI
                   :security_schemes,
                   :example_types,
                   :response_headers,
-                  :path_records
+                  :path_records,
+                  :config_filename
   end
 end

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -26,6 +26,8 @@ module RSpec::OpenAPI
   @example_types = %i[request]
   @response_headers = []
   @path_records = Hash.new { |h, k| h[k] = [] }
+
+  # This is the configuraion override file name we look for within each path.
   @config_filename = 'rspec_openapi.rb'
 
   class << self
@@ -40,7 +42,8 @@ module RSpec::OpenAPI
                   :security_schemes,
                   :example_types,
                   :response_headers,
-                  :path_records,
-                  :config_filename
+                  :path_records
+
+    attr_reader   :config_filename
   end
 end

--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -9,6 +9,10 @@ class RSpec::OpenAPI::ResultRecorder
   def record_results!
     title = File.basename(Dir.pwd)
     @path_records.each do |path, records|
+      # Look for a path-specific config file and run it.
+      config_file = File.join(File.dirname(path), RSpec::OpenAPI.config_filename)
+      eval(File.read(config_file)) if File.exist?(config_file)
+
       RSpec::OpenAPI::SchemaFile.new(path).edit do |spec|
         schema = RSpec::OpenAPI::DefaultSchema.build(title)
         schema[:info].merge!(RSpec::OpenAPI.info)


### PR DESCRIPTION
Closes https://github.com/exoego/rspec-openapi/issues/161
----

Complex API's often use different server paths and have specific title and other information for different services. The purpose of this PR is to allow for such configurations to be overridden within each path defined in `RSpec::OpenAPI.path`. The PR also allows for the naming of the config file (defaulting to `rspec_openapi.rb`).

While the current initializer can define all the paths and common settings like the request and response headers, security schemes, and others, the path-based configuration files can be used to define server and other path/service-specific information.