### PR TITLE
Sort HTTP methods, response status codes, and contents lexicographically

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -9,6 +9,7 @@ require 'rspec/openapi/schema_builder'
 require 'rspec/openapi/schema_file'
 require 'rspec/openapi/schema_merger'
 require 'rspec/openapi/schema_cleaner'
+require 'rspec/openapi/schema_sorter'
 
 require 'rspec/openapi/minitest_hooks' if Object.const_defined?('Minitest')
 require 'rspec/openapi/rspec_hooks' if ENV['OPENAPI'] && Object.const_defined?('RSpec')

--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -24,7 +24,7 @@ class RSpec::OpenAPI::ResultRecorder
         RSpec::OpenAPI::SchemaCleaner.cleanup!(spec, new_from_zero)
         RSpec::OpenAPI::ComponentsUpdater.update!(spec, new_from_zero)
         RSpec::OpenAPI::SchemaCleaner.cleanup_empty_required_array!(spec)
-        RSpec::OpenAPI::SchemaCleaner.sort_paths!(spec)
+        RSpec::OpenAPI::SchemaSorter.deep_sort!(spec)
       end
     end
   end

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -51,13 +51,6 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     end
   end
 
-  # Sort "paths" lexicographically to make the order more predictable
-  #
-  # @param [Hash]   #
-  def sort_paths!(spec)
-    spec['paths'] = spec['paths']&.entries&.sort_by! { |path, _| path }.to_h
-  end
-
   private
 
   def cleanup_array!(base, spec, selector, fields_for_identity = [])

--- a/lib/rspec/openapi/schema_sorter.rb
+++ b/lib/rspec/openapi/schema_sorter.rb
@@ -28,10 +28,8 @@ class << RSpec::OpenAPI::SchemaSorter = Object.new
     end
   end
 
-  def deep_sort_hash!(v)
-    if v.is_a?(Hash)
-      sorted = v.entries.sort_by { |k,v| k }.to_h
-      v.replace(sorted)
-    end
+  def deep_sort_hash!(hash)
+    sorted = hash.entries.sort_by { |k,v| k }.to_h
+    hash.replace(sorted)
   end
 end

--- a/lib/rspec/openapi/schema_sorter.rb
+++ b/lib/rspec/openapi/schema_sorter.rb
@@ -29,7 +29,7 @@ class << RSpec::OpenAPI::SchemaSorter = Object.new
   end
 
   def deep_sort_hash!(hash)
-    sorted = hash.entries.sort_by { |k,v| k }.to_h
+    sorted = hash.entries.sort_by { |k, _| k }.to_h
     hash.replace(sorted)
   end
 end

--- a/lib/rspec/openapi/schema_sorter.rb
+++ b/lib/rspec/openapi/schema_sorter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class << RSpec::OpenAPI::SchemaSorter = Object.new
+  # Sort some unpredictably ordered properties in a lexicographical manner to make the order more predictable.
+  #
+  # @param [Hash|Array]
+  def deep_sort!(spec)
+    # paths
+    deep_sort_by_selector!(spec, 'paths')
+
+    # methods
+    deep_sort_by_selector!(spec, 'paths.*')
+
+    # response status code
+    deep_sort_by_selector!(spec, 'paths.*.*.responses')
+
+    # content-type
+    deep_sort_by_selector!(spec, 'paths.*.*.responses.*.content')
+  end
+
+  private
+
+  # @param [Hash] base
+  # @param [String] selector
+  def deep_sort_by_selector!(base, selector)
+    RSpec::OpenAPI::HashHelper.matched_paths(base, selector).each do |paths|
+      deep_sort_hash!(base.dig(*paths))
+    end
+  end
+
+  def deep_sort_hash!(v)
+    if v.is_a?(Hash)
+      sorted = v.entries.sort_by { |k,v| k }.to_h
+      v.replace(sorted)
+    end
+  end
+end

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -347,30 +347,83 @@
         "tags": [
           "Table"
         ],
-        "responses": {
-          "401": {
-            "description": "does not return tables if unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ]
-                },
-                "example": {
-                  "message": "Unauthorized"
+        "parameters": [
+          {
+            "name": "X-Authorization-Token",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "token"
+          },
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
                 }
-              }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "example": {
+              "name": "Example Table"
             }
           },
+          {
+            "name": "filter[price]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "price": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "price"
+              ]
+            },
+            "example": {
+              "price": "0"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          },
+          {
+            "name": "per",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 10
+          }
+        ],
+        "responses": {
           "200": {
             "description": "with different deep query parameters",
+            "headers": {
+              "X-Cursor": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -444,120 +497,36 @@
                   }
                 ]
               }
-            },
-            "headers": {
-              "X-Cursor": {
+            }
+          },
+          "401": {
+            "description": "does not return tables if unauthorized",
+            "content": {
+              "application/json": {
                 "schema": {
-                  "type": "integer"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                },
+                "example": {
+                  "message": "Unauthorized"
                 }
               }
             }
           }
-        },
-        "parameters": [
-          {
-            "name": "X-Authorization-Token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "example": "token"
-          },
-          {
-            "name": "filter[name]",
-            "in": "query",
-            "required": false,
-            "description": "Filter by name",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "example": {
-              "name": "Example Table"
-            }
-          },
-          {
-            "name": "filter[price]",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "price": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "price"
-              ]
-            },
-            "example": {
-              "price": "0"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            },
-            "example": 1
-          },
-          {
-            "name": "per",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            },
-            "example": 10
-          }
-        ]
+        }
       },
       "post": {
         "summary": "create",
         "tags": [
           "Table"
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "database_id": {
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "name",
-                  "description",
-                  "database_id"
-                ]
-              },
-              "example": {
-                "name": "k0kubun",
-                "description": "description",
-                "database_id": 2
-              }
-            }
-          }
-        },
         "responses": {
           "201": {
             "description": "returns a table",
@@ -652,10 +621,154 @@
               }
             }
           }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "database_id": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "name",
+                  "description",
+                  "database_id"
+                ]
+              },
+              "example": {
+                "name": "k0kubun",
+                "description": "description",
+                "database_id": 2
+              }
+            }
+          }
         }
       }
     },
     "/tables/{id}": {
+      "delete": {
+        "summary": "destroy",
+        "tags": [
+          "Table"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns a table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "database": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    },
+                    "null_sample": {
+                      "nullable": true
+                    },
+                    "storage_size": {
+                      "type": "number",
+                      "format": "float"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "database",
+                    "null_sample",
+                    "storage_size",
+                    "created_at",
+                    "updated_at"
+                  ]
+                },
+                "example": {
+                  "id": 1,
+                  "name": "access",
+                  "description": "logs",
+                  "database": {
+                    "id": 2,
+                    "name": "production"
+                  },
+                  "null_sample": null,
+                  "storage_size": 12.3,
+                  "created_at": "2020-07-17T00:00:00+00:00",
+                  "updated_at": "2020-07-17T00:00:00+00:00"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "returns no content if specified"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "no_content": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "no_content"
+                ]
+              },
+              "example": {
+                "no_content": "true"
+              }
+            }
+          }
+        }
+      },
       "get": {
         "summary": "show",
         "tags": [
@@ -895,120 +1008,6 @@
                   "created_at": "2020-07-17T00:00:00+00:00",
                   "updated_at": "2020-07-17T00:00:00+00:00"
                 }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "destroy",
-        "tags": [
-          "Table"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            },
-            "example": 1
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "returns a table",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "database": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "name"
-                      ]
-                    },
-                    "null_sample": {
-                      "nullable": true
-                    },
-                    "storage_size": {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    "created_at": {
-                      "type": "string"
-                    },
-                    "updated_at": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "description",
-                    "database",
-                    "null_sample",
-                    "storage_size",
-                    "created_at",
-                    "updated_at"
-                  ]
-                },
-                "example": {
-                  "id": 1,
-                  "name": "access",
-                  "description": "logs",
-                  "database": {
-                    "id": 2,
-                    "name": "production"
-                  },
-                  "null_sample": null,
-                  "storage_size": 12.3,
-                  "created_at": "2020-07-17T00:00:00+00:00",
-                  "updated_at": "2020-07-17T00:00:00+00:00"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "returns no content if specified"
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "no_content": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "no_content"
-                ]
-              },
-              "example": {
-                "no_content": "true"
               }
             }
           }

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -226,7 +226,6 @@ paths:
       - name: filter[name]
         in: query
         required: false
-        description: Filter by name
         schema:
           type: object
           properties:
@@ -263,6 +262,10 @@ paths:
       responses:
         '200':
           description: with different deep query parameters
+          headers:
+            X-Cursor:
+              schema:
+                type: integer
           content:
             application/json:
               schema:
@@ -315,10 +318,6 @@ paths:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
-          headers:
-            X-Cursor:
-              schema:
-                type: integer
         '401':
           description: does not return tables if unauthorized
           content:
@@ -336,26 +335,6 @@ paths:
       summary: create
       tags:
       - Table
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                database_id:
-                  type: integer
-              required:
-              - name
-              - description
-              - database_id
-            example:
-              name: k0kubun
-              description: description
-              database_id: 2
       responses:
         '201':
           description: returns a table
@@ -422,7 +401,105 @@ paths:
                 - error
               example:
                 error: invalid name parameter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                database_id:
+                  type: integer
+              required:
+              - name
+              - description
+              - database_id
+            example:
+              name: k0kubun
+              description: description
+              database_id: 2
   "/tables/{id}":
+    delete:
+      summary: destroy
+      tags:
+      - Table
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 1
+      responses:
+        '200':
+          description: returns a table
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  database:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                  null_sample:
+                    nullable: true
+                  storage_size:
+                    type: number
+                    format: float
+                  created_at:
+                    type: string
+                  updated_at:
+                    type: string
+                required:
+                - id
+                - name
+                - description
+                - database
+                - null_sample
+                - storage_size
+                - created_at
+                - updated_at
+              example:
+                id: 1
+                name: access
+                description: logs
+                database:
+                  id: 2
+                  name: production
+                null_sample:
+                storage_size: 12.3
+                created_at: '2020-07-17T00:00:00+00:00'
+                updated_at: '2020-07-17T00:00:00+00:00'
+        '202':
+          description: returns no content if specified
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                no_content:
+                  type: string
+              required:
+              - no_content
+            example:
+              no_content: 'true'
     get:
       summary: show
       tags:
@@ -589,84 +666,6 @@ paths:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
-    delete:
-      summary: destroy
-      tags:
-      - Table
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
-        example: 1
-      responses:
-        '200':
-          description: returns a table
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                  name:
-                    type: string
-                  description:
-                    type: string
-                  database:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                      name:
-                        type: string
-                    required:
-                    - id
-                    - name
-                  null_sample:
-                    nullable: true
-                  storage_size:
-                    type: number
-                    format: float
-                  created_at:
-                    type: string
-                  updated_at:
-                    type: string
-                required:
-                - id
-                - name
-                - description
-                - database
-                - null_sample
-                - storage_size
-                - created_at
-                - updated_at
-              example:
-                id: 1
-                name: access
-                description: logs
-                database:
-                  id: 2
-                  name: production
-                null_sample:
-                storage_size: 12.3
-                created_at: '2020-07-17T00:00:00+00:00'
-                updated_at: '2020-07-17T00:00:00+00:00'
-        '202':
-          description: returns no content if specified
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                no_content:
-                  type: string
-              required:
-              - no_content
-            example:
-              no_content: 'true'
   "/test_block":
     get:
       summary: GET /test_block


### PR DESCRIPTION
Closes #159 

# Changes

This is a generalization of #155 

The below keys are sorted lexicographically.

- API Paths. E.g.) `/users/`, `/users/{id}`. This is already implemented in #155, but refactored.
- HTTP methods. E.g.) `get`, `delete`, `post`, `put`
- Response status codes. E.g.) `200`, `301`, `400`, `500`
- Response content-types: E.g.) `application/json`, `text/plain`

Keys in other places remain as-is.


# Alternative considered
I initially implemented sorting every `Hash`, but it is not good.
Keys of some places should remain as-is.

E.g.) Some top-level keys. It makes a bit surprising if`openapi:` keys are in the very bottom of the file. 

```yaml
openapi: 3.0.3
info:
  title: OpenAPI Documentation
  version: 1.0.0
servers: []
paths:
```


E.g.) The properties of schema. I assume users defined properties as they feel it natural.
```yaml
  schemas:
    Table:
      type: object
      properties:
        id:
          type: integer
        # This field should exists in expected
        # name:
        #  type: string
        this_field_should_not_exist_in_expected:
          type: string
        description:
          type: string
        database:
          "$ref": "#/components/schemas/Database"
        columns:
          type: array
          items:
            "$ref": "#/components/schemas/Column"
        null_sample:
          nullable: true
        storage_size:
          type: number
          format: float
        created_at:
          type: string
        updated_at:
          type: string
```

