### PR TITLE
Correctly normalize rails paths with optional bound params

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -216,7 +216,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
   end
 
   def normalize_path(path)
-    path.gsub(%r{/:([^:/]+)}, '/{\1}')
+    path.gsub(%r{/:([^:/)]+)}, '/{\1}')
   end
 
   def normalize_content_type(content_type)

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -203,6 +203,16 @@ class ImageTest < ActionDispatch::IntegrationTest
   end
 end
 
+class OptionalParamTest < ActionDispatch::IntegrationTest
+  i_suck_and_my_tests_are_order_dependent!
+  openapi!
+
+  test 'returns a payload' do
+    get '/optional_params/17'
+    assert_response 200
+  end
+end
+
 class SecretKeyTest < ActionDispatch::IntegrationTest
   i_suck_and_my_tests_are_order_dependent!
   openapi!

--- a/spec/rails/app/controllers/optional_params_controller.rb
+++ b/spec/rails/app/controllers/optional_params_controller.rb
@@ -1,0 +1,5 @@
+class OptionalParamsController < ApplicationController
+  def display
+    render json: { id: params[:id] || 'id' }
+  end
+end

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -20,5 +20,7 @@ Rails.application.routes.draw do
     get '/test_block' => ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }
 
     get '/secret_items' => 'secret_items#index'
+
+    get 'optional_params(/:id)', to: 'optional_params#display'
   end
 end

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -341,6 +341,48 @@
         }
       }
     },
+    "/optional_params(/{id})": {
+      "get": {
+        "summary": "display",
+        "tags": [
+          "OptionalParam"
+        ],
+        "responses": {
+          "200": {
+            "description": "returns a payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                },
+                "example": {
+                  "id": "17"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 17
+          }
+        ]
+      }
+    },
     "/secret_items": {
       "get": {
         "summary": "index",

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -211,6 +211,32 @@ paths:
               schema:
                 type: string
               example: ANOTHER TEST
+  "/optional_params(/{id})":
+    get:
+      summary: display
+      tags:
+      - OptionalParam
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 17
+      responses:
+        '200':
+          description: returns a payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                - id
+              example:
+                id: '17'
   "/secret_items":
     get:
       summary: index

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -206,6 +206,15 @@ RSpec.describe 'Images', type: :request do
   end
 end
 
+RSpec.describe 'OptionalParams', type: :request do
+  describe '#display' do
+    it 'returns a payload' do
+      get '/optional_params/17'
+      expect(response.status).to eq(200)
+    end
+  end
+end
+
 RSpec.describe 'SecretKey securityScheme',
                type: :request,
                openapi: { security: [{ 'SecretApiKeyAuth' => [] }] } do


### PR DESCRIPTION
Rails supports [optional bound parameters](https://guides.rubyonrails.org/routing.html#bound-parameters).

When using optional params, the generated paths by this gem look something like: `/optional_params/(/{id)}` instead of the expected `/optional_params/(/{id})`

If you use tools like [widdershins](https://www.npmjs.com/package/widdershins) to generate docs from your OpenAPI specification, this can break the parsing.

This PR updates the regex to not include the closing parentheses in the capture group during path normalization.