### PR TITLE
Merge manually added `oneOf` schemas

### DIFF
--- a/lib/rspec/openapi/components_updater.rb
+++ b/lib/rspec/openapi/components_updater.rb
@@ -74,6 +74,7 @@ class << RSpec::OpenAPI::ComponentsUpdater = Object.new
     nested_refs = [
       *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, 'components.schemas', 'properties.*.$ref'),
       *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, 'components.schemas', 'properties.*.items.$ref'),
+      *RSpec::OpenAPI::HashHelper.matched_paths_deeply_nested(base, 'components.schemas', 'oneOf.*.$ref'),
     ]
     # Reject already-generated schemas to reduce unnecessary loop
     nested_refs.reject do |paths|

--- a/lib/rspec/openapi/components_updater.rb
+++ b/lib/rspec/openapi/components_updater.rb
@@ -23,7 +23,7 @@ class << RSpec::OpenAPI::ComponentsUpdater = Object.new
       #  0             1         2 ^...............................^
       # ["components", "schema", "Table", "properties", "owner", "properties", "company", "$ref"]
       #  0             1         2 ^...........................................^
-      needle = paths.reject { _1.is_a?(Integer) || _1 == 'oneOf' }
+      needle = paths.reject { |path| path.is_a?(Integer) || path == 'oneOf' }
       needle = needle.slice(2, needle.size - 3)
       nested_schema = fresh_schemas.dig(*needle)
 

--- a/lib/rspec/openapi/components_updater.rb
+++ b/lib/rspec/openapi/components_updater.rb
@@ -85,9 +85,9 @@ class << RSpec::OpenAPI::ComponentsUpdater = Object.new
   end
 
   def find_one_of_refs(base, paths)
-    dig_schema(base, paths)&.dig('oneOf')&.filter_map&.with_index do |schema, index|
+    dig_schema(base, paths)&.dig('oneOf')&.map&.with_index do |schema, index|
       paths + [index] if schema&.dig('$ref')&.start_with?('#/components/schemas/')
-    end
+    end&.compact
   end
 
   def find_object_refs(base, paths)

--- a/lib/rspec/openapi/hash_helper.rb
+++ b/lib/rspec/openapi/hash_helper.rb
@@ -8,6 +8,10 @@ class << RSpec::OpenAPI::HashHelper = Object.new
         k = k.to_s
         [[k]] + paths_to_all_fields(v).map { |x| [k, *x] }
       end
+    when Array
+      obj.flat_map.with_index do |value, i|
+        [[i]] + paths_to_all_fields(value).map { |x| [i, *x] }
+      end
     else
       []
     end

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -100,10 +100,8 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
 
         intersection = first.keys & second.keys
         total_size = [first.size, second.size].max.to_f
-        keys_score = intersection.size / total_size
-        values_score = intersection.sum { |key| similarity(first[key], second[key]) } / total_size
 
-        (keys_score + values_score) / 2.0
+        intersection.sum { |key| similarity(first[key], second[key]) } / total_size
       else
         0
       end

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -29,6 +29,12 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   #
   # TODO: Should we probably force-merge `summary` regardless of manual modifications?
   def merge_schema!(base, spec)
+    if (options = base['oneOf'])
+      merge_closest_match!(options, spec)
+
+      return base
+    end
+
     spec.each do |key, value|
       if base[key].is_a?(Hash) && value.is_a?(Hash)
         merge_schema!(base[key], value) unless base[key].key?('$ref')
@@ -66,5 +72,38 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
 
     all_parameters.uniq! { |param| param.slice('name', 'in') }
     base[key] = all_parameters
+  end
+
+  SIMILARITY_THRESHOLD = 0.5
+
+  def merge_closest_match!(options, spec)
+    score, option = options.map { |option| [similarity(option, spec), option] }.max_by(&:first)
+
+    if score && score > SIMILARITY_THRESHOLD
+      merge_schema!(option, spec)
+    else
+      options.push(spec)
+    end
+  end
+
+  def similarity(first, second)
+    return 1 if first == second
+
+    score =
+      case [first.class, second.class]
+      when [Array, Array]
+        (first & second).size / [first.size, second.size].max.to_f
+      when [Hash, Hash]
+        intersection = first.keys & second.keys
+        total_size = [first.size, second.size].max.to_f
+        keys_score = intersection.size / total_size
+        values_score = intersection.sum { |key| similarity(first[key], second[key]) } / total_size
+
+        (keys_score + values_score) / 2.0
+      else
+        0
+      end
+
+    score.finite? ? score : 0
   end
 end

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -79,7 +79,9 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   def merge_closest_match!(options, spec)
     score, option = options.map { |option| [similarity(option, spec), option] }.max_by(&:first)
 
-    if score && score > SIMILARITY_THRESHOLD
+    return if option&.key?('$ref')
+
+    if score.to_f > SIMILARITY_THRESHOLD
       merge_schema!(option, spec)
     else
       options.push(spec)
@@ -94,6 +96,8 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
       when [Array, Array]
         (first & second).size / [first.size, second.size].max.to_f
       when [Hash, Hash]
+        return 1 if first.merge(second).key?('$ref')
+
         intersection = first.keys & second.keys
         total_size = [first.size, second.size].max.to_f
         keys_score = intersection.size / total_size

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -114,15 +114,30 @@ paths:
                   description:
                     type: string
                   database:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                      name:
-                        type: string
-                    required:
-                      - id
-                      - name
+                    discriminator:
+                      propertyName: name
+                    oneOf:
+                    - type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                      required:
+                        - id
+                        - name
+                    - type: object
+                      properties:
+                        name:
+                          type: string
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                        user:
+                          type: string
+                        schema:
+                          type: string
                   null_sample:
                     nullable: true
                   storage_size:

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -117,6 +117,34 @@ paths:
                     discriminator:
                       propertyName: name
                     oneOf:
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                          user:
+                            type: string
+                          schema:
+                            type: string
+                    - type: object
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                        user:
+                          type: string
+                        schema:
+                          type: string
+                      required:
+                        - host
+                        - port
+                        - schema
                     - type: object
                       properties:
                         id:
@@ -126,18 +154,6 @@ paths:
                       required:
                         - id
                         - name
-                    - type: object
-                      properties:
-                        name:
-                          type: string
-                        host:
-                          type: string
-                        port:
-                          type: integer
-                        user:
-                          type: string
-                        schema:
-                          type: string
                   null_sample:
                     nullable: true
                   storage_size:
@@ -176,7 +192,9 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PostUsersRequest"
+              oneOf:
+              - "$ref": "#/components/schemas/PostUsersRequest"
+              - type: string
             example:
               name: alice
               avatar_url: "https://example.com/avatar.png"

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -308,22 +308,37 @@ components:
         - name
         - column_type
     User:
-      type: object
-      properties:
-        name:
-          type: string
-        relations:
-          type: object
-          properties:
-            avatar:
-              "$ref": "#/components/schemas/Avatar"
-            pets:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Pet"
-          required:
-            - avatar
-            - pets
+      discriminator:
+        propertyName: name
+      oneOf:
+      - type: object
+        properties:
+          name:
+            type: string
+          foo:
+            type: string
+          bar:
+            type: string
+          baz:
+            type: string
+          quux:
+            type: string
+      - type: object
+        properties:
+          name:
+            type: string
+          relations:
+            type: object
+            properties:
+              avatar:
+                "$ref": "#/components/schemas/Avatar"
+              pets:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            required:
+              - avatar
+              - pets
     Avatar:
       type: object
       properties:

--- a/spec/rails/doc/smart/openapi.yaml
+++ b/spec/rails/doc/smart/openapi.yaml
@@ -174,12 +174,27 @@ paths:
                   description:
                     type: string
                   database:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                      name:
-                        type: string
+                    discriminator:
+                      propertyName: name
+                    oneOf:
+                    - type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                    - type: object
+                      properties:
+                        name:
+                          type: string
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                        user:
+                          type: string
+                        schema:
+                          type: string
                   null_sample:
                     nullable: true
                   storage_size:

--- a/spec/rails/doc/smart/openapi.yaml
+++ b/spec/rails/doc/smart/openapi.yaml
@@ -294,16 +294,31 @@ components:
         id:
           type: integer
     User:
-      type: object
-      properties:
-        name:
-          type: string
-        relations:
-          type: object
-          properties:
-            avatar:
-              "$ref": "#/components/schemas/Avatar"
-            pets:
-              type: array
-              items:
-                "$ref": "#/components/schemas/Pet"
+      discriminator:
+        propertyName: name
+      oneOf:
+      - type: object
+        properties:
+          name:
+            type: string
+          foo:
+            type: string
+          bar:
+            type: string
+          baz:
+            type: string
+          quux:
+            type: string
+      - type: object
+        properties:
+          name:
+            type: string
+          relations:
+            type: object
+            properties:
+              avatar:
+                "$ref": "#/components/schemas/Avatar"
+              pets:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"

--- a/spec/rails/doc/smart/openapi.yaml
+++ b/spec/rails/doc/smart/openapi.yaml
@@ -177,16 +177,22 @@ paths:
                     discriminator:
                       propertyName: name
                     oneOf:
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                          user:
+                            type: string
+                          schema:
+                            type: string
                     - type: object
                       properties:
-                        id:
-                          type: integer
-                        name:
-                          type: string
-                    - type: object
-                      properties:
-                        name:
-                          type: string
                         host:
                           type: string
                         port:
@@ -195,6 +201,10 @@ paths:
                           type: string
                         schema:
                           type: string
+                      required:
+                        - host
+                        - port
+                        - schema
                   null_sample:
                     nullable: true
                   storage_size:
@@ -227,7 +237,9 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PostUsersRequest"
+              oneOf:
+              - "$ref": "#/components/schemas/PostUsersRequest"
+              - type: string
       responses:
         '201':
           description: returns a user


### PR DESCRIPTION
As reported in #173, manually added `oneOf` attributes are ignored and the generated schema is placed alongside.

This PR implements an algorithm that compare the generated schema with every `oneOf` option, merges with the most similar one, or adds a new option if none are sufficiently similar.

I placed an abitrary value of 0.5 that represents the minimum similarity score required.

I have to update the `$ref` handling code too, since it was discarding paths inside arrays.