### PR TITLE
Additional properties override

### DIFF
--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -36,16 +36,14 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
     end
 
     spec.each do |key, value|
-      # allow `additionalProperties` to override generated property modifications
-      next if base.key?('additionalProperties') && %w[properties required].include?(key)
-
       if base[key].is_a?(Hash) && value.is_a?(Hash)
         merge_schema!(base[key], value) unless base[key].key?('$ref')
       elsif base[key].is_a?(Array) && value.is_a?(Array)
         # parameters need to be merged as if `name` and `in` were the Hash keys.
         merge_arrays(base, key, value)
       else
-        base[key] = value
+        # do not add `properties` or `required` fields if `additionalProperties` field is present
+        base[key] = value unless base.key?('additionalProperties') && %w[properties required].include?(key)
       end
     end
     base

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -36,6 +36,9 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
     end
 
     spec.each do |key, value|
+      # allow `additionalProperties` to override generated property modifications
+      next if base.key?('additionalProperties') && %w[properties required].include?(key)
+
       if base[key].is_a?(Hash) && value.is_a?(Hash)
         merge_schema!(base[key], value) unless base[key].key?('$ref')
       elsif base[key].is_a?(Array) && value.is_a?(Array)

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -42,7 +42,7 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
         # parameters need to be merged as if `name` and `in` were the Hash keys.
         merge_arrays(base, key, value)
       else
-        # do not add `properties` or `required` fields if `additionalProperties` field is present
+        # do not ADD `properties` or `required` fields if `additionalProperties` field is present
         base[key] = value unless base.key?('additionalProperties') && %w[properties required].include?(key)
       end
     end

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -245,3 +245,13 @@ class EngineExtraRoutesTest < ActionDispatch::IntegrationTest
     assert_response 200
   end
 end
+
+class AdditionalPropertiesTest < ActionDispatch::IntegrationTest
+  i_suck_and_my_tests_are_order_dependent!
+  openapi!
+
+  test 'returns some content' do
+    get '/additional_properties'
+    assert_response 200
+  end
+end

--- a/spec/rails/app/controllers/additional_properties_controller.rb
+++ b/spec/rails/app/controllers/additional_properties_controller.rb
@@ -1,0 +1,13 @@
+class AdditionalPropertiesController < ApplicationController
+  def index
+    response = {
+      required_key: 'value',
+      variadic_key: {
+        gold: 1,
+        silver: 2,
+        bronze: 3
+      }
+    }
+    render json: response
+  end
+end

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -20,5 +20,7 @@ Rails.application.routes.draw do
     get '/test_block' => ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }
 
     get '/secret_items' => 'secret_items#index'
+
+    get '/additional_properties' => 'additional_properties#index'
   end
 end

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -15,6 +15,49 @@
     }
   ],
   "paths": {
+    "/additional_properties": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "AdditionalProperty"
+        ],
+        "responses": {
+          "200": {
+            "description": "returns some content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "required_key": {
+                      "type": "string"
+                    },
+                    "variadic_key": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "required": [
+                    "required_key",
+                    "variadic_key"
+                  ]
+                },
+                "example": {
+                  "required_key": "value",
+                  "variadic_key": {
+                    "gold": 1,
+                    "silver": 2,
+                    "bronze": 3
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/images": {
       "get": {
         "summary": "index",

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -21,7 +21,7 @@ paths:
       - AdditionalProperty
       responses:
         '200':
-          description: returns some content
+          description: returns the block content
           content:
             application/json:
               schema:

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -21,7 +21,7 @@ paths:
       - AdditionalProperty
       responses:
         '200':
-          description: returns the block content
+          description: returns some content
           content:
             application/json:
               schema:

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -14,6 +14,34 @@ info:
 servers:
 - url: http://localhost:3000
 paths:
+  "/additional_properties":
+    get:
+      summary: index
+      tags:
+      - AdditionalProperty
+      responses:
+        '200':
+          description: returns some content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  required_key:
+                    type: string
+                  variadic_key:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                required:
+                - required_key
+                - variadic_key
+              example:
+                required_key: value
+                variadic_key:
+                  gold: 1
+                  silver: 2
+                  bronze: 3
   "/images":
     get:
       summary: index

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -14,34 +14,6 @@ info:
 servers:
 - url: http://localhost:3000
 paths:
-  "/additional_properties":
-    get:
-      summary: index
-      tags:
-      - AdditionalProperty
-      responses:
-        '200':
-          description: returns some content
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  required_key:
-                    type: string
-                  variadic_key:
-                    type: object
-                    additionalProperties:
-                      type: integer
-                required:
-                - required_key
-                - variadic_key
-              example:
-                required_key: value
-                variadic_key:
-                  gold: 1
-                  silver: 2
-                  bronze: 3
   "/tables":
     get:
       summary: index

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -14,6 +14,34 @@ info:
 servers:
 - url: http://localhost:3000
 paths:
+  "/additional_properties":
+    get:
+      summary: index
+      tags:
+      - AdditionalProperty
+      responses:
+        '200':
+          description: returns some content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  required_key:
+                    type: string
+                  variadic_key:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                required:
+                - required_key
+                - variadic_key
+              example:
+                required_key: value
+                variadic_key:
+                  gold: 1
+                  silver: 2
+                  bronze: 3
   "/tables":
     get:
       summary: index

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -246,3 +246,12 @@ RSpec.describe 'Engine extra routes', type: :request do
     end
   end
 end
+
+RSpec.describe 'Additional Properties test', type: :request do
+  describe '#test' do
+    it 'returns the block content' do
+      get '/additional_properties'
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -249,7 +249,7 @@ end
 
 RSpec.describe 'Additional Properties test', type: :request do
   describe '#test' do
-    it 'returns the block content' do
+    it 'returns some content' do
       get '/additional_properties'
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
A possible implementation to address [Issue 132](https://github.com/exoego/rspec-openapi/issues/132).  This will not add a `properties` or `required` field if `additionalProperties` exists on the base schema.  It will still update those fields if they are already present on the base, I feel that is a decent compromise to resolve that issue and not interfere with schemas where all three fields are intentionally present.