### PR TITLE
Use GitHub releases as a single source of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# THIS CHANGELOG IS DEPRECATED!!
+
+Refer https://github.com/exoego/rspec-openapi/releases instead.
+
 ## v0.12.0
 
 - feat: Initial support of complex schema with manually-added `oneOf`

--- a/rspec-openapi.gemspec
+++ b/rspec-openapi.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = spec.homepage
-  spec.metadata['changelog_uri'] = File.join(spec.homepage, 'blob/master/CHANGELOG.md')
+  spec.metadata = {
+    'homepage_uri'    => spec.homepage,
+    'source_code_uri' => spec.homepage,
+    'changelog_uri'   => File.join(spec.homepage, 'blob/master/CHANGELOG.md'),
+  }
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/rspec-openapi.gemspec
+++ b/rspec-openapi.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata = {
-    'homepage_uri'    => spec.homepage,
-    'source_code_uri' => spec.homepage,
-    'changelog_uri'   => File.join(spec.homepage, 'blob/master/CHANGELOG.md'),
+    'homepage_uri'    => 'https://github.com/exoego/rspec-openapi',
+    'source_code_uri' => 'https://github.com/exoego/rspec-openapi',
+    'changelog_uri'   => "https://github.com/exoego/rspec-openapi/releases/tag/v#{RSpec::OpenAPI::VERSION}",
   }
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/rspec-openapi.gemspec
+++ b/rspec-openapi.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata = {
-    'homepage_uri'    => 'https://github.com/exoego/rspec-openapi',
+    'homepage_uri' => 'https://github.com/exoego/rspec-openapi',
     'source_code_uri' => 'https://github.com/exoego/rspec-openapi',
-    'changelog_uri'   => "https://github.com/exoego/rspec-openapi/releases/tag/v#{RSpec::OpenAPI::VERSION}",
+    'changelog_uri' => "https://github.com/exoego/rspec-openapi/releases/tag/v#{RSpec::OpenAPI::VERSION}",
+    'rubygems_mfa_required' => 'true',
   }
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do


### PR DESCRIPTION
This eases releasing 