### PR TITLE
fix: Remove content field if no content

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -14,12 +14,15 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
     if record.response_body
       disposition = normalize_content_disposition(record.response_content_disposition)
 
-      response[:content] = {
-        normalize_content_type(record.response_content_type) => {
-          schema: build_property(record.response_body, disposition: disposition),
-          example: response_example(record, disposition: disposition),
-        }.compact,
-      }
+      has_content = !normalize_content_type(record.response_content_type).nil?
+      if has_content
+        response[:content] = {
+          normalize_content_type(record.response_content_type) => {
+            schema: build_property(record.response_body, disposition: disposition),
+            example: response_example(record, disposition: disposition),
+          }.compact,
+        }
+      end
     end
 
     {

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -19,6 +19,13 @@ paths:
       summary: get
       tags:
       - Page
+      parameters:
+        - name: head
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 1
       responses:
         '200':
           description: return HTML
@@ -27,8 +34,8 @@ paths:
               schema:
                 type: string
               example: '<!DOCTYPE html><html lang="en"><head><title>Hello</title></head><body>Hello</body></html>'
-#        '204':
-#          description: return no content
+        '204':
+          description: return no content
   "/tables":
     get:
       summary: index

--- a/spec/requests/rails_smart_merge_spec.rb
+++ b/spec/requests/rails_smart_merge_spec.rb
@@ -117,5 +117,10 @@ RSpec.describe 'Pages', type: :request do
       get '/pages'
       expect(response.status).to eq(200)
     end
+
+    it 'return no content' do
+      get '/pages?head=1'
+      expect(response.status).to eq(204)
+    end
   end
 end


### PR DESCRIPTION
Empty `content` is injected ...
<img width="559" alt="image" src="https://github.com/exoego/rspec-openapi/assets/127635/b31daba6-8d7e-4296-b67d-d8ccaf3d2c57">

However, `content` should not be added for no content response, according to
> https://swagger.io/docs/specification/describing-responses/
> <img width="605" alt="image" src="https://github.com/exoego/rspec-openapi/assets/127635/2afd49db-20ac-4c33-a205-feaf658cccdc">

