### PR TITLE
Generate empty request body

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -25,16 +25,17 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       end
     end
 
+    http_method = record.http_method.downcase
     {
       paths: {
         normalize_path(record.path) => {
-          record.http_method.downcase => {
+          http_method => {
             summary: record.summary,
             tags: record.tags,
             operationId: record.operation_id,
             security: record.security,
             parameters: build_parameters(record),
-            requestBody: build_request_body(record),
+            requestBody: http_method == 'get' ? nil : build_request_body(record),
             responses: {
               record.status.to_s => response,
             },
@@ -123,7 +124,6 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
 
   def build_request_body(record)
     return nil if record.request_content_type.nil?
-    return nil if record.request_params.empty?
     return nil if record.status >= 400
 
     {

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -47,7 +47,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
   private
 
   def enrich_with_required_keys(obj)
-    obj[:required] = obj[:properties]&.keys
+    obj[:required] = obj[:properties]&.keys || []
     obj
   end
 

--- a/spec/rails/app/controllers/users_controller.rb
+++ b/spec/rails/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def create
     res = {
-      name: params[:name],
+      name: params[:name] || 'alice',
       relations: {
         avatar: {
           url: params[:avatar_url] || 'https://example.com/avatar.png',

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -854,10 +854,7 @@
                   "no_content": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "no_content"
-                ]
+                }
               },
               "example": {
                 "no_content": "true"

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -555,8 +555,6 @@ paths:
               properties:
                 no_content:
                   type: string
-              required:
-              - no_content
             example:
               no_content: 'true'
     get:

--- a/spec/rails/doc/smart/expected.yaml
+++ b/spec/rails/doc/smart/expected.yaml
@@ -411,9 +411,5 @@ components:
               properties:
                 baz:
                   type: integer
-              required:
-                - baz
           required:
             - bar
-      required:
-        - name

--- a/spec/requests/rails_smart_merge_spec.rb
+++ b/spec/requests/rails_smart_merge_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe 'Users', type: :request do
       expect(response.status).to eq(201)
     end
 
+    it 'accepts nested object where some fields are missing' do
+      post '/users', headers: { authorization: 'k0kubun', 'Content-Type': 'application/json' }, params: {
+        name: 'alice',
+        foo: {
+          bar: {
+          },
+        },
+      }.to_json
+      expect(response.status).to eq(201)
+    end
+
+    it 'can accept empty body' do
+      post '/users', headers: { authorization: 'k0kubun', 'Content-Type': 'application/json' }, params: {}.to_json
+      expect(response.status).to eq(201)
+    end
+
     it 'returns an user' do
       post '/users', headers: { authorization: 'k0kubun', 'Content-Type': 'application/json' }, params: {
         name: 'alice',

--- a/spec/requests/rails_smart_merge_spec.rb
+++ b/spec/requests/rails_smart_merge_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe 'Users', type: :request do
       post '/users', headers: { authorization: 'k0kubun', 'Content-Type': 'application/json' }, params: {
         name: 'alice',
         foo: {
-          bar: {
-          },
+          bar: {},
         },
       }.to_json
       expect(response.status).to eq(201)


### PR DESCRIPTION
Closes #195 

The current implementation does not generate an empty request body (e.g., `{}` for `application/javascript`).
This leads to always-required top-level properties reported in #195

```yaml
 PostUsersRequest: 
   type: object 
   properties: 
     name: 
       type: string 
   required:
     - name
```
