### PR TITLE
normali

### DIFF
--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -5,6 +5,7 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   # @param [Hash] spec
   def merge!(base, spec)
     spec = normalize_keys(spec)
+    base = normalize_keys(base)
     merge_schema!(base, spec)
   end
 

--- a/spec/rspec/scheme_merger_spec.rb
+++ b/spec/rspec/scheme_merger_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'schema merger spec' do
+  include SpecHelper
+
+  describe 'mixed symbol and strings' do
+    let(:base) do
+      {
+        'n' => 1,
+        'required' => %w[foo bar],
+        'a' => {
+          b1: 1,
+          b2: %w[foo bar],
+          'b3' => {
+            'c1' => 2,
+            c2: 3,
+          },
+        },
+      }
+    end
+
+    let(:spec) do
+      {
+        n: 1,
+        required: ['buz'],
+        a: {
+          'b1' => 1,
+          'b2' => %w[foo bar],
+          b3: {
+            c1: 2,
+            'c2' => 3,
+          },
+        },
+      }
+    end
+
+    it 'normalize symbol to string' do
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+      expect(result).to eq({
+                             'n' => 1,
+                             'required' => [],
+                             'a' => {
+                               'b1' => 1,
+                               'b2' => %w[foo bar],
+                               'b3' => {
+                                 'c1' => 2,
+                                 'c2' => 3,
+                               },
+                             },
+                           })
+    end
+  end
+end


### PR DESCRIPTION
During #196, I found string and symbols are mixed up.

String keys come from the base file (`YAML.safe_load(File.read(@path))`) and Symbol keys come from the generate specs.
Since String != Symbol, merge is buggy.