### PR TITLE
Fixes invalid merge logic

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -10,6 +10,7 @@ require 'rspec/openapi/schema_file'
 require 'rspec/openapi/schema_merger'
 require 'rspec/openapi/schema_cleaner'
 require 'rspec/openapi/schema_sorter'
+require 'rspec/openapi/key_transformer'
 
 require 'rspec/openapi/minitest_hooks' if Object.const_defined?('Minitest')
 require 'rspec/openapi/rspec_hooks' if ENV['OPENAPI'] && Object.const_defined?('RSpec')

--- a/lib/rspec/openapi/key_transformer.rb
+++ b/lib/rspec/openapi/key_transformer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class << RSpec::OpenAPI::KeyTransformer = Object.new
+  def symbolize(value)
+    case value
+    when Hash
+      value.to_h { |k, v| [k.to_sym, symbolize(v)] }
+    when Array
+      value.map { |v| symbolize(v) }
+    else
+      value
+    end
+  end
+
+  def stringify(value)
+    case value
+    when Hash
+      value.to_h { |k, v| [k.to_s, stringify(v)] }
+    when Array
+      value.map { |v| stringify(v) }
+    else
+      value
+    end
+  end
+end

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -53,7 +53,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
 
   def extract_headers(request, response)
     request_headers = RSpec::OpenAPI.request_headers.each_with_object([]) do |header, headers_arr|
-      header_key = header.gsub('-', '_').upcase
+      header_key = header.gsub('-', '_').upcase.to_sym
       header_value = request.get_header(['HTTP', header_key].join('_')) || request.get_header(header_key)
       headers_arr << [header, header_value] if header_value
     end

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -27,7 +27,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     cleanup_hash!(base, spec, 'paths.*.*')
 
     # cleanup parameters
-    cleanup_array!(base, spec, 'paths.*.*.parameters', %w[name in])
+    cleanup_array!(base, spec, 'paths.*.*.parameters', %i[name in])
 
     # cleanup requestBody
     cleanup_hash!(base, spec, 'paths.*.*.requestBody.content.application/json.schema.properties.*')
@@ -40,7 +40,7 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
   end
 
   def cleanup_conflicting_security_parameters!(base)
-    security_schemes = base.dig('components', 'securitySchemes') || {}
+    security_schemes = base.dig(:components, :securitySchemes) || {}
 
     return if security_schemes.empty?
 
@@ -65,22 +65,22 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     paths_to_objects.each do |path|
       parent = base.dig(*path.take(path.length - 1))
       # "required" array  must not be present if empty
-      parent.delete('required') if parent['required'] && parent['required'].empty?
+      parent.delete(:required) if parent[:required] && parent[:required].empty?
     end
   end
 
   private
 
   def remove_parameters_conflicting_with_security_sceheme!(path_definition, security_scheme, security_scheme_name)
-    return unless path_definition['security']
-    return unless path_definition['parameters']
-    return unless path_definition.dig('security', 0).keys.include?(security_scheme_name)
+    return unless path_definition[:security]
+    return unless path_definition[:parameters]
+    return unless path_definition.dig(:security, 0).keys.include?(security_scheme_name)
 
-    path_definition['parameters'].reject! do |parameter|
-      parameter['in'] == security_scheme['in'] && # same location (ie. header)
-        parameter['name'] == security_scheme['name'] # same name (ie. AUTHORIZATION)
+    path_definition[:parameters].reject! do |parameter|
+      parameter[:in] == security_scheme[:in] && # same location (ie. header)
+        parameter[:name] == security_scheme[:name] # same name (ie. AUTHORIZATION)
     end
-    path_definition.delete('parameters') if path_definition['parameters'].empty?
+    path_definition.delete(:parameters) if path_definition[:parameters].empty?
   end
 
   def cleanup_array!(base, spec, selector, fields_for_identity = [])

--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -15,7 +15,7 @@ class RSpec::OpenAPI::SchemaFile
     spec = read
     block.call(spec)
   ensure
-    write(stringify(spec))
+    write(RSpec::OpenAPI::KeyTransformer.stringify(spec))
   end
 
   private
@@ -24,29 +24,7 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
-  end
-
-  def symbolize(value)
-    case value
-    when Hash
-      value.to_h { |k, v| [k.to_sym, symbolize(v)] }
-    when Array
-      value.map { |v| symbolize(v) }
-    else
-      value
-    end
-  end
-
-  def stringify(value)
-    case value
-    when Hash
-      value.to_h { |k, v| [k.to_s, stringify(v)] }
-    when Array
-      value.map { |v| stringify(v) }
-    else
-      value
-    end
+    RSpec::OpenAPI::KeyTransformer.symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
   end
 
   # @param [Hash] spec

--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -15,7 +15,7 @@ class RSpec::OpenAPI::SchemaFile
     spec = read
     block.call(spec)
   ensure
-    write(spec)
+    write(stringify(spec))
   end
 
   private
@@ -24,7 +24,29 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    YAML.safe_load(File.read(@path)) # this can also parse JSON
+    symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
+  end
+
+  def symbolize(value)
+    case value
+    when Hash
+      value.to_h { |k, v| [k.to_sym, symbolize(v)] }
+    when Array
+      value.map { |v| symbolize(v) }
+    else
+      value
+    end
+  end
+
+  def stringify(value)
+    case value
+    when Hash
+      value.to_h { |k, v| [k.to_s, stringify(v)] }
+    when Array
+      value.map { |v| stringify(v) }
+    else
+      value
+    end
   end
 
   # @param [Hash] spec

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -4,25 +4,12 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   # @param [Hash] base
   # @param [Hash] spec
   def merge!(base, spec)
-    spec = normalize_keys(spec)
-    base.replace(normalize_keys(base))
+    spec = RSpec::OpenAPI::KeyTransformer.symbolize(spec)
+    base.replace(RSpec::OpenAPI::KeyTransformer.symbolize(base))
     merge_schema!(base, spec)
   end
 
   private
-
-  def normalize_keys(spec)
-    case spec
-    when Hash
-      spec.to_h do |key, value|
-        [key.to_sym, normalize_keys(value)]
-      end
-    when Array
-      spec.map { |s| normalize_keys(s) }
-    else
-      spec
-    end
-  end
 
   # Not doing `base.replace(deep_merge(base, spec))` to preserve key orders.
   # Also this needs to be aware of OpenAPI details because a Hash-like structure

--- a/lib/rspec/openapi/schema_sorter.rb
+++ b/lib/rspec/openapi/schema_sorter.rb
@@ -29,7 +29,7 @@ class << RSpec::OpenAPI::SchemaSorter = Object.new
   end
 
   def deep_sort_hash!(hash)
-    sorted = hash.entries.sort_by { |k, _| k }.to_h
+    sorted = hash.entries.sort_by { |k, _| k.to_s }.to_h.transform_keys(&:to_sym)
     hash.replace(sorted)
   end
 end

--- a/spec/rspec/scheme_merger_spec.rb
+++ b/spec/rspec/scheme_merger_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'schema merger spec' do
+  include SpecHelper
+
+  describe 'mixed symbol and strings' do
+    let(:base) do
+      {
+        'n' => 1,
+        'required' => %w[foo bar],
+        'a' => {
+          b1: 1,
+          b2: %w[foo bar],
+          'b3' => {
+            'c1' => 2,
+            c2: 3,
+          },
+        },
+      }
+    end
+
+    let(:spec) do
+      {
+        n: 1,
+        required: ['buz'],
+        a: {
+          'b1' => 1,
+          'b2' => %w[foo bar],
+          b3: {
+            c1: 2,
+            'c2' => 3,
+          },
+        },
+      }
+    end
+
+    it 'normalize keys to symbol' do
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+      expect(result).to eq({
+                             n: 1,
+                             required: [],
+                             a: {
+                               b1: 1,
+                               b2: %w[foo bar],
+                               b3: {
+                                 c1: 2,
+                                 c2: 3,
+                               },
+                             },
+                           })
+    end
+  end
+end


### PR DESCRIPTION
During #196, I found string and symbols are mixed up.

String keys come from the base file (`YAML.safe_load(File.read(@path))`) and Symbol keys come from the generate specs.
Since String != Symbol, merge is buggy, as seen in https://github.com/exoego/rspec-openapi/pull/198/commits/c941c62b4a3e90076d0c4b317a8393519bed557e

This PR symbolizes all keys during processing.
Keys are transformed to String back when dumping into YAML file.