### PR TITLE
Introduce Post-Processing Hook for OpenAPI Spec Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ RSpec::OpenAPI.ignored_path_params = %i[controller action format]
 # In that case, you can specify the paths to ignore.
 # String or Regexp is acceptable.
 RSpec::OpenAPI.ignored_paths = ["/admin/full/path/", Regexp.new("^/_internal/")]
+
+# Your custom post-processing hook (like unrandomizing IDs)
+RSpec::OpenAPI.post_process_hook = -> (path, records, spec) do
+  RSpec::OpenAPI::HashHelper.matched_paths(spec, 'paths.*.*.responses.*.content.*.*.*.id').each do |paths|
+    spec.dig(*paths[0..-2]).merge!(id: '123')
+  end
+end
 ```
 
 ### Can I use rspec-openapi with `$ref` to minimize duplication of schema?

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -33,6 +33,7 @@ module RSpec::OpenAPI
   @path_records = Hash.new { |h, k| h[k] = [] }
   @ignored_path_params = %i[controller action format]
   @ignored_paths = []
+  @post_process_hook = nil
 
   # This is the configuraion override file name we look for within each path.
   @config_filename = 'rspec_openapi.rb'
@@ -54,7 +55,8 @@ module RSpec::OpenAPI
                   :response_headers,
                   :path_records,
                   :ignored_paths,
-                  :ignored_path_params
+                  :ignored_path_params,
+                  :post_process_hook
 
     attr_reader   :config_filename
   end

--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -34,6 +34,9 @@ class RSpec::OpenAPI::ResultRecorder
         RSpec::OpenAPI::ComponentsUpdater.update!(spec, new_from_zero)
         RSpec::OpenAPI::SchemaCleaner.cleanup_empty_required_array!(spec)
         RSpec::OpenAPI::SchemaSorter.deep_sort!(spec)
+        if RSpec::OpenAPI.post_process_hook.is_a?(Proc)
+          RSpec::OpenAPI.post_process_hook.call(path, records, spec)
+        end
       end
     end
   end

--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -29,14 +29,8 @@ class RSpec::OpenAPI::ResultRecorder
         rescue StandardError, NotImplementedError => e # e.g. SchemaBuilder raises a NotImplementedError
           @error_records[e] = record # Avoid failing the build
         end
-        RSpec::OpenAPI::SchemaCleaner.cleanup_conflicting_security_parameters!(spec)
-        RSpec::OpenAPI::SchemaCleaner.cleanup!(spec, new_from_zero)
-        RSpec::OpenAPI::ComponentsUpdater.update!(spec, new_from_zero)
-        RSpec::OpenAPI::SchemaCleaner.cleanup_empty_required_array!(spec)
-        RSpec::OpenAPI::SchemaSorter.deep_sort!(spec)
-        if RSpec::OpenAPI.post_process_hook.is_a?(Proc)
-          RSpec::OpenAPI.post_process_hook.call(path, records, spec)
-        end
+        cleanup_schema!(new_from_zero, spec)
+        execute_post_process_hook(path, records, spec)
       end
     end
   end
@@ -51,5 +45,19 @@ class RSpec::OpenAPI::ResultRecorder
 
       #{@error_records.map { |e, record| "#{e.inspect}: #{record.inspect}" }.join("\n")}
     ERR_MSG
+  end
+
+  private
+
+  def execute_post_process_hook(path, records, spec)
+    RSpec::OpenAPI.post_process_hook.call(path, records, spec) if RSpec::OpenAPI.post_process_hook.is_a?(Proc)
+  end
+
+  def cleanup_schema!(new_from_zero, spec)
+    RSpec::OpenAPI::SchemaCleaner.cleanup_conflicting_security_parameters!(spec)
+    RSpec::OpenAPI::SchemaCleaner.cleanup!(spec, new_from_zero)
+    RSpec::OpenAPI::ComponentsUpdater.update!(spec, new_from_zero)
+    RSpec::OpenAPI::SchemaCleaner.cleanup_empty_required_array!(spec)
+    RSpec::OpenAPI::SchemaSorter.deep_sort!(spec)
   end
 end

--- a/spec/apps/rails/doc/openapi.json
+++ b/spec/apps/rails/doc/openapi.json
@@ -1139,5 +1139,6 @@
         "name": "Secret-Key"
       }
     }
-  }
+  },
+  "custom_field": "custom_value"
 }

--- a/spec/apps/rails/doc/openapi.yaml
+++ b/spec/apps/rails/doc/openapi.yaml
@@ -742,3 +742,4 @@ components:
       type: apiKey
       in: header
       name: Secret-Key
+custom_field: custom_value

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -34,9 +34,7 @@ RSpec::OpenAPI.security_schemes = {
   },
 }
 
-RSpec::OpenAPI.post_process_hook = -> (path, records, spec) do
-  spec['custom_field'] = 'custom_value'
-end
+RSpec::OpenAPI.post_process_hook = ->(_path, _records, spec) { spec['custom_field'] = 'custom_value' }
 
 class TablesIndexTest < ActionDispatch::IntegrationTest
   i_suck_and_my_tests_are_order_dependent!

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -34,6 +34,10 @@ RSpec::OpenAPI.security_schemes = {
   },
 }
 
+RSpec::OpenAPI.post_process_hook = -> (path, records, spec) do
+  spec['custom_field'] = 'custom_value'
+end
+
 class TablesIndexTest < ActionDispatch::IntegrationTest
   i_suck_and_my_tests_are_order_dependent!
   openapi!


### PR DESCRIPTION
### Description

This PR introduces a new feature: a post-processing hook that allows for custom modifications of the OpenAPI spec generated by our RSpec tests. It enables users to apply transformations or additions to the spec, such as unrandomizing IDs or adding custom fields, after the spec has been generated but before it is finalised.

### Changes

1. **README.md**: Updated to include documentation on how to utilize the new `post_process_hook` to apply custom modifications to the OpenAPI spec.
2. **lib/rspec/openapi.rb**: Added a new class variable `@post_process_hook` initialized as `nil` and made it accessible via `attr_accessor`.
3. **lib/rspec/openapi/result_recorder.rb**: Refactored spec cleanup and updating into a new private method `cleanup_schema!` and added `execute_post_process_hook`, which calls the user-defined `post_process_hook` if it's provided.
4. **Integration and Documentation**: Applied the post-processing hook in test environments to add a custom field `"custom_field": "custom_value"` to the OpenAPI JSON and YAML docs as a proof of concept.

### Motivation

This enhancement was motivated by the need for greater flexibility in generating OpenAPI specs. Users often have specific requirements for their OpenAPI documentation, such as consistent example values, additional metadata, or custom formatting. By introducing a post-processing hook, we empower users to tailor the generated specs to their precise needs without modifying the core logic of rspec-openapi.

### Usage

To utilize this feature, set the `RSpec::OpenAPI.post_process_hook` to a lambda that accepts `path`, `records`, and `spec` as arguments. Within this lambda, users can manipulate the `spec` as needed. For example:

```ruby
RSpec::OpenAPI.post_process_hook = -> (path, records, spec) do
  spec['custom_field'] = 'custom_value'
end
```

This PR provides a foundational step towards more customizable and user-friendly OpenAPI spec generation, opening the door for numerous extensions and customizations based on user feedback and evolving requirements.