### PR TITLE
fix: warn when Hanami or Rails are not detected

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -18,7 +18,7 @@ require 'rspec/openapi/extractors/rack'
 begin
   require 'hanami'
 rescue LoadError
-  puts 'Hanami not detected'
+  warn 'Hanami not detected'
 else
   require 'rspec/openapi/extractors/hanami'
 end
@@ -26,7 +26,7 @@ end
 begin
   require 'rails'
 rescue LoadError
-  puts 'Rails not detected'
+  warn 'Rails not detected'
 else
   require 'rspec/openapi/extractors/rails'
 end


### PR DESCRIPTION
I started noticing "Hanami not detected" lately.  I'm not sure exactly what to recommend here, perhaps only output anything when `ENV["CI"] == "true"` or something like that.. but I think preferring warn -> stderr over puts -> stdout is a good start to lower the shoutiness of it.