### PR TITLE
Fix ID not found

### DIFF
--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -48,13 +48,14 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
       path = route.path.spec.to_s.delete_suffix('(.:format)')
 
       if route.app.matches?(request)
+        path_id = add_id(request.path, parameters)
         if route.app.engine?
           route, path = find_rails_route(request, app: route.app.app, path_prefix: path)
           next if route.nil?
-        elsif path_prefix + path == add_id(request.path, parameters)
+        elsif path_prefix + path == path_id
           return [route, path_prefix + path]
         else
-          return [route, nil]
+          return [route, path_id]
         end
         return [route, path_prefix + path]
       end


### PR DESCRIPTION
Hi, thanks for sharing this amazing gem. I updated to version 0.18.1 and I ran into a problem when trying to create openapi from an endpoint in which a non-existent ID is passed as a parameter. Something like:

```rb
context 'when resource not found' do
  let(:resource_id) { 'abc123' }

  before do
    get resource_url(resource_id), as: :json
  end

  it { is_expected.to have_http_status(:not_found) }
end
```
Locally I managed to correct the behavior through this code. In the 0.17.0 version everything was working perfectly fine. I hope this helps in some way and that it continues to evolve. Thank you very much.


