### PR TITLE
regression: non-numeric path parameter raises on Rails

### DIFF
--- a/lib/rspec/openapi/extractors/hanami.rb
+++ b/lib/rspec/openapi/extractors/hanami.rb
@@ -19,7 +19,10 @@ class Inspector
   def call(verb, path)
     route = routes.find { |r| r.http_method == verb && r.path == path }
 
-    if route.to.is_a?(Proc)
+    if route.nil?
+      # FIXME: This is a hack to pass `/sites/***` in testing
+      {}
+    elsif route.to.is_a?(Proc)
       {
         tags: [],
         summary: "#{verb} #{path}",

--- a/spec/apps/hanami/app/actions/sites/show.rb
+++ b/spec/apps/hanami/app/actions/sites/show.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module HanamiTest
+  module Actions
+    module Sites
+      class Show < SiteAction
+        format :json
+
+        def handle(request, response)
+          response.body = find_site(request.params[:name]).to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/apps/hanami/app/actions/sites/site_action.rb
+++ b/spec/apps/hanami/app/actions/sites/site_action.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module HanamiTest
+  module Actions
+    module Sites
+      class SiteAction < HanamiTest::Action
+        include SiteRepository
+
+        handle_exception RecordNotFound => :handle_not_fount_error
+
+        private
+
+        def handle_not_fount_error(_request, response, _exception)
+          response.status = 404
+          response.body = { message: 'not found' }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/apps/hanami/app/actions/sites/site_repository.rb
+++ b/spec/apps/hanami/app/actions/sites/site_repository.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module HanamiTest
+  module Actions
+    module Sites
+      module SiteRepository
+        class RecordNotFound < StandardError; end
+
+        def find_site(name = nil)
+          case name
+          when 'abc123', nil
+            {
+              name: name,
+            }
+          else
+            raise RecordNotFound
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/apps/hanami/config/routes.rb
+++ b/spec/apps/hanami/config/routes.rb
@@ -23,6 +23,8 @@ module HanamiTest
     get '/users/:id', to: 'users.show'
     get '/users/active', to: 'users.active'
 
+    get '/sites/:name', to: 'sites.show'
+
     get '/test_block', to: ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }
 
     slice :my_engine, at: '/my_engine' do

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -431,6 +431,60 @@
         }
       }
     },
+    "/sites/abc123": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "finds a site",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "example": {
+                  "name": "abc123"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sites/no-such": {
+      "get": {
+        "responses": {
+          "404": {
+            "description": "raises not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                },
+                "example": {
+                  "message": "not found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tables": {
       "get": {
         "summary": "index",

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -265,6 +265,38 @@ paths:
               schema:
                 type: string
               example: ''
+  "/sites/abc123":
+    get:
+      responses:
+        '200':
+          description: finds a site
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+              example:
+                name: abc123
+  "/sites/no-such":
+    get:
+      responses:
+        '404':
+          description: raises not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+              example:
+                message: not found
   "/tables":
     get:
       summary: index

--- a/spec/apps/rails/app/controllers/sites_controller.rb
+++ b/spec/apps/rails/app/controllers/sites_controller.rb
@@ -1,0 +1,18 @@
+class SitesController < ApplicationController
+  def show
+    render json: find_site(params[:name])
+  end
+
+  private
+
+  def find_site(name = nil)
+    case name
+    when 'abc123', nil
+      {
+        name: name,
+      }
+    else
+      raise NotFoundError
+    end
+  end
+end

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   defaults format: 'json' do
+    resources :sites, param: :name, only: [:show]
     resources :tables, only: [:index, :show, :create, :update, :destroy]
     resources :images, only: [:index, :show] do
       collection do

--- a/spec/apps/rails/doc/openapi.json
+++ b/spec/apps/rails/doc/openapi.json
@@ -474,6 +474,69 @@
         }
       }
     },
+    "/sites/{name}": {
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Site"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "no-such"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "finds a site",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "example": {
+                  "name": "abc123"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "raises not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                },
+                "example": {
+                  "message": "not found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tables": {
       "get": {
         "summary": "index",

--- a/spec/apps/rails/doc/openapi.yaml
+++ b/spec/apps/rails/doc/openapi.yaml
@@ -292,6 +292,45 @@ paths:
               schema:
                 type: string
               example: ''
+  "/sites/{name}":
+    get:
+      summary: show
+      tags:
+      - Site
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        example: no-such
+      responses:
+        '200':
+          description: finds a site
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+              example:
+                name: abc123
+        '404':
+          description: raises not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+              example:
+                message: not found
   "/tables":
     get:
       summary: index

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -288,3 +288,18 @@ class RackAppTest < ActionDispatch::IntegrationTest
     assert_response 200
   end
 end
+
+class RackAppTest < ActionDispatch::IntegrationTest
+  i_suck_and_my_tests_are_order_dependent!
+  openapi!
+
+  test 'raises not found' do
+    get '/sites/no-such', as: :json
+    assert_response 404
+  end
+
+  test 'finds a site' do
+    get '/sites/abc123', as: :json
+    assert_response 200
+  end
+end

--- a/spec/requests/hanami_spec.rb
+++ b/spec/requests/hanami_spec.rb
@@ -297,3 +297,15 @@ RSpec.describe 'Rack app test', type: :request do
     end
   end
 end
+
+RSpec.describe 'non-numeric path parameter', type: :request do
+  it 'finds a site' do
+    get '/sites/abc123'
+    expect(last_response.status).to eq(200)
+  end
+
+  it 'raises not found' do
+    get '/sites/no-such'
+    expect(last_response.status).to eq(404)
+  end
+end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -286,3 +286,15 @@ RSpec.describe 'Rack app test', type: :request do
     end
   end
 end
+
+RSpec.describe 'non-numeric path parameter', type: :request do
+  it 'finds a site' do
+    get '/sites/abc123', as: :json
+    expect(response.status).to eq(200)
+  end
+
+  it 'raises not found' do
+    get '/sites/no-such', as: :json
+    expect(response.status).to eq(404)
+  end
+end


### PR DESCRIPTION
Part of #224

Note that Hanami implementation is still broken.
`spec/apps/hanami/doc/openapi.(json|yaml)` should have `/sites/{name}` path, but `/sites/abc123` and `/sites/no-such` instead.

