### PR TITLE
Fixes generation issues in Roda

### DIFF
--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -12,9 +12,9 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
 
     route, path = find_rails_route(fixed_request)
 
-    raise "No route matched for #{fixed_request.request_method} #{fixed_request.path_info}" if route.nil?
-
     return RSpec::OpenAPI::Extractors::Rack.request_attributes(request, example) unless path
+
+    raise "No route matched for #{fixed_request.request_method} #{fixed_request.path_info}" if route.nil?
 
     metadata = example.metadata[:openapi] || {}
     summary = metadata[:summary] || RSpec::OpenAPI.summary_builder.call(example)

--- a/spec/apps/roda/doc/openapi.json
+++ b/spec/apps/roda/doc/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Override title",
+    "title": "OpenAPI Documentation",
     "version": "7.7.7"
   },
   "servers": [

--- a/spec/apps/roda/doc/openapi.yaml
+++ b/spec/apps/roda/doc/openapi.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.3
 info:
-  title: Override title
+  title: OpenAPI Documentation
   version: 7.7.7
 servers: []
 paths:


### PR DESCRIPTION
I recently created a new project on rails 8rc1 and installed Rodauth-rails. Rodauth-rails is an authorization framework based on Roda. When trying to generate an openapi spec from a simple test:
```ruby
require 'rails_helper'

RSpec.describe "Auth::CreateAccounts", type: :request do
  describe "POST /create-account" do
    let(:password) { "Criptograf123!" }
    let(:email) { "test@example.com" }
    let(:params) { { email:, password: } }
    before { post "/create-account", params:, as: :json }

    it "create account" do
      expect(response).to have_http_status(200)
    end

    context "when email invalid" do
      let(:email) { "com" }

      it "NOT create account" do
        expect(response).to have_http_status(422)
      end
    end

    context "when email invalid" do
      let(:password) { "1234" }

      it "NOT create account" do
        expect(response).to have_http_status(422)
      end
    end
  end
end
```
I got the following problems:
```bash
Failure/Error: example.run
     
     RuntimeError:
       No route matched for POST /create-account
     # .../gems_bundle/ruby/3.3.0/gems/rspec-openapi-0.18.3/lib/rspec/openapi/extractors/rails.rb:15:in `request_attributes'
     # .../gems_bundle/ruby/3.3.0/gems/rspec-openapi-0.18.3/lib/rspec/openapi/record_builder.rb:15:in `build'
     # .../gems_bundle/ruby/3.3.0/gems/rspec-openapi-0.18.3/lib/rspec/openapi/rspec_hooks.rb:8:in `block in <main>'
     # ./spec/support/database_cleaner.rb:10:in `block (3 levels) in <main>'
     # .../gems_bundle/ruby/3.3.0/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in `cleaning'
     # .../gems_bundle/ruby/3.3.0/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in `block (2 levels) in cleaning'
     # .../gems_bundle/ruby/3.3.0/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in `cleaning'
     # ./spec/support/database_cleaner.rb:9:in `block (2 levels) in <main>'
```
This is an exception from `raise "No route matched for #{fixed_request.request_method} #{fixed_request.path_info}" if route.nil?` [link](https://github.com/exoego/rspec-openapi/blob/master/lib/rspec/openapi/extractors/rails.rb#L15)

I noticed that if you swap line 15 and 17 of the code, everything works fine.

Perhaps additional checks are required for these cases, haven't had time to look into it, I'll get back to it as time permits if no one looks into it sooner.