### PR TITLE
Evaluate proc for RSpec::OpenAPI.title

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,17 @@ RSpec::OpenAPI.path = -> (example) {
   end
 }
 
+# Change the default title of the generated schema
 RSpec::OpenAPI.title = 'OpenAPI Documentation'
+
+# Or generate individual titles for your partial schema files, given an RSpec example
+RSpec::OpenAPI.title = -> (example) {
+  case example.file_path
+  when %r[spec/requests/api/v1/] then 'API v1 Documentation'
+  when %r[spec/requests/api/v2/] then 'API v2 Documentation'
+  else 'OpenAPI Documentation'
+  end
+}
 
 # Disable generating `example`
 RSpec::OpenAPI.enable_example = false

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec::OpenAPI::Record = Struct.new(
+  :title,                 # @param [String]  - "API Documentation - Statuses"
   :http_method,           # @param [String]  - "GET"
   :path,                  # @param [String]  - "/v1/status/:id"
   :path_params,           # @param [Hash]    - {:controller=>"v1/statuses", :action=>"create", :id=>"1"}

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -11,6 +11,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     request, response = extractor.request_response(context)
     return if request.nil?
 
+    title = RSpec::OpenAPI.title.then { |t| t.is_a?(Proc) ? t.call(example) : t }
     path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated =
       extractor.request_attributes(request, example)
 
@@ -19,6 +20,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     request_headers, response_headers = extract_headers(request, response)
 
     RSpec::OpenAPI::Record.new(
+      title: title,
       http_method: request.method,
       path: path,
       path_params: raw_path_params,

--- a/lib/rspec/openapi/result_recorder.rb
+++ b/lib/rspec/openapi/result_recorder.rb
@@ -16,7 +16,7 @@ class RSpec::OpenAPI::ResultRecorder
         puts "WARNING: Unable to load #{config_file}: #{e}"
       end
 
-      title = RSpec::OpenAPI.title
+      title = records.first.title
       RSpec::OpenAPI::SchemaFile.new(path).edit do |spec|
         schema = RSpec::OpenAPI::DefaultSchema.build(title)
         schema[:info].merge!(RSpec::OpenAPI.info)


### PR DESCRIPTION
### Description:
Solution to #171. With the additional logic you can make the title dynamic using the same approach used with the path, and maintain backward compatibility. This allows the generation of individual schema files, each with its own title.

### Example:
It's possible to assign titles in 2 ways:
```ruby
# Change the default title of the generated schema
RSpec::OpenAPI.title = 'OpenAPI Documentation'

# Or generate individual titles for your partial schema files, given an RSpec example
RSpec::OpenAPI.title = -> (example) {
  case example.file_path
  when %r[spec/requests/api/v1/] then 'API v1 Documentation'
  when %r[spec/requests/api/v2/] then 'API v2 Documentation'
  else 'OpenAPI Documentation'
  end
}
```

I updated the documentation with this information. I left a [comment](https://github.com/exoego/rspec-openapi/issues/171#issuecomment-2429550727) with an alternative solution in case it's preferred