### PR TITLE
Fix semantic error caused by requestBody in deletes

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -36,7 +36,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
             security: record.security,
             deprecated: record.deprecated ? true : nil,
             parameters: build_parameters(record),
-            requestBody: http_method == 'get' ? nil : build_request_body(record),
+            requestBody: include_nil_request_body?(http_method) ? nil : build_request_body(record),
             responses: {
               record.status.to_s => response,
             },
@@ -47,6 +47,10 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
   end
 
   private
+
+  def include_nil_request_body?(http_method)
+    %w[delete get].include?(http_method)
+  end
 
   def enrich_with_required_keys(obj)
     obj[:required] = obj[:properties]&.keys || []

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -824,23 +824,6 @@
             "example": 1
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "no_content": {
-                    "type": "string"
-                  }
-                }
-              },
-              "example": {
-                "no_content": "true"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "returns a table",

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -581,16 +581,6 @@ paths:
                 updated_at: '2020-07-17T00:00:00+00:00'
         '202':
           description: returns no content if specified
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                no_content:
-                  type: string
-            example:
-              no_content: 'true'
     get:
       summary: show
       tags:

--- a/spec/apps/rails/doc/openapi.json
+++ b/spec/apps/rails/doc/openapi.json
@@ -943,23 +943,6 @@
           "202": {
             "description": "returns no content if specified"
           }
-        },
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "no_content": {
-                    "type": "string"
-                  }
-                }
-              },
-              "example": {
-                "no_content": "true"
-              }
-            }
-          }
         }
       },
       "get": {

--- a/spec/apps/rails/doc/openapi.yaml
+++ b/spec/apps/rails/doc/openapi.yaml
@@ -608,16 +608,6 @@ paths:
                 updated_at: '2020-07-17T00:00:00+00:00'
         '202':
           description: returns no content if specified
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                no_content:
-                  type: string
-            example:
-              no_content: 'true'
     get:
       summary: show
       tags:


### PR DESCRIPTION
While testing some generated docs which included a `DELETE` operation, the [Swagger editor](https://editor.swagger.io/) gave me the following error:

```
Semantic error at paths./views/{id}.delete.requestBody
DELETE operations cannot have a requestBody.
```

When I looked into it, I found out that in [v3.0.3 of the OpenAPI Spec](https://spec.openapis.org/oas/v3.0.3#fixed-fields-7) (which is what this gem currently generates), a `requestBody` in a `DELETE` operation is not allowed, as the HTTP 1.1 specification [Section 4.3.1](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1) does not have explicitly defined semantics for request bodies in `DELETE`.

This has changed in [v3.1.0](https://spec.openapis.org/oas/v3.1.0#fixed-fields-7), where for such operations, `requestBody` is permitted but does not have well-defined semantics and, as per the specification, should be avoided if possible.

The `schema_builder` was already using a nil `requestBody` for `GET` requests, so I have modified it slightly to do the same for `DELETE`.