### PR TITLE
Fix rspec issues caused by changes to concurrent-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
   gem 'hanami-router', ENV['HANAMI_VERSION'] || '2.1.0'
 end
 
+gem 'concurrent-ruby', '1.3.4'
+
 gem 'roda'
 
 gem 'rails-dom-testing', '~> 2.2'


### PR DESCRIPTION
As per https://stackoverflow.com/a/79361034, concurrent-ruby v1.3.5 has removed the dependency on logger, causing issues with the activesupport gem.