### PR TITLE
Add support for parameter format specification in schema building

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -33,6 +33,7 @@ module RSpec::OpenAPI
   @description_builder = ->(example) { example.description }
   @summary_builder = ->(example) { example.metadata[:summary] }
   @tags_builder = ->(example) { example.metadata[:tags] }
+  @formats_builder = ->(example) { example.metadata[:formats] }
   @info = {}
   @application_version = '1.0.0'
   @request_headers = []
@@ -56,6 +57,7 @@ module RSpec::OpenAPI
                   :description_builder,
                   :summary_builder,
                   :tags_builder,
+                  :formats_builder,
                   :info,
                   :application_version,
                   :request_headers,

--- a/lib/rspec/openapi/extractors/hanami.rb
+++ b/lib/rspec/openapi/extractors/hanami.rb
@@ -59,6 +59,7 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
     metadata = example.metadata[:openapi] || {}
     summary = metadata[:summary] || RSpec::OpenAPI.summary_builder.call(example)
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
+    formats = metadata[:formats] || RSpec::OpenAPI.formats_builder.curry.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
     security = metadata[:security]
@@ -76,7 +77,18 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
 
     raw_path_params = raw_path_params.slice(*(raw_path_params.keys - RSpec::OpenAPI.ignored_path_params))
 
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [
+      path,
+      summary,
+      tags,
+      operation_id,
+      required_request_params,
+      raw_path_params,
+      description,
+      security,
+      deprecated,
+      formats,
+    ]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rack.rb
+++ b/lib/rspec/openapi/extractors/rack.rb
@@ -9,6 +9,7 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
     metadata = example.metadata[:openapi] || {}
     summary = metadata[:summary] || RSpec::OpenAPI.summary_builder.call(example)
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
+    formats = metadata[:formats] || RSpec::OpenAPI.formats_builder.curry.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
     security = metadata[:security]
@@ -17,7 +18,18 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
     raw_path_params = request.path_parameters
     path = request.path
     summary ||= "#{request.method} #{path}"
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [
+      path,
+      summary,
+      tags,
+      operation_id,
+      required_request_params,
+      raw_path_params,
+      description,
+      security,
+      deprecated,
+      formats,
+    ]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -19,6 +19,8 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
     metadata = example.metadata[:openapi] || {}
     summary = metadata[:summary] || RSpec::OpenAPI.summary_builder.call(example)
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
+    formats = metadata[:formats] || RSpec::OpenAPI.formats_builder.curry.call(example)
+
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
     security = metadata[:security]
@@ -34,7 +36,18 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
 
     summary ||= "#{request.method} #{path}"
 
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [
+      path,
+      summary,
+      tags,
+      operation_id,
+      required_request_params,
+      raw_path_params,
+      description,
+      security,
+      deprecated,
+      formats,
+    ]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -12,6 +12,7 @@ RSpec::OpenAPI::Record = Struct.new(
   :request_headers,       # @param [Array]  - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
   :summary,               # @param [String]  - "v1/statuses #show"
   :tags,                  # @param [Array]   - ["Status"]
+  :formats,               # @param [Proc]    - ->(key) { key.end_with?('_at') ? 'date-time' : nil }
   :operation_id,          # @param [String]   - "request-1234"
   :description,           # @param [String]  - "returns a status"
   :security,              # @param [Array]  - [{securityScheme1: []}]

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -12,7 +12,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     return if request.nil?
 
     title = RSpec::OpenAPI.title.then { |t| t.is_a?(Proc) ? t.call(example) : t }
-    path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated =
+    path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated, formats =
       extractor.request_attributes(request, example)
 
     return if RSpec::OpenAPI.ignored_paths.any? { |ignored_path| path.match?(ignored_path) }
@@ -31,6 +31,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       request_headers: request_headers,
       summary: summary,
       tags: tags,
+      formats: formats,
       operation_id: operation_id,
       description: description,
       security: security,

--- a/spec/apps/rails/doc/openapi.json
+++ b/spec/apps/rails/doc/openapi.json
@@ -659,10 +659,12 @@
                         "format": "float"
                       },
                       "created_at": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "date-time"
                       },
                       "updated_at": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "date-time"
                       }
                     },
                     "required": [
@@ -763,10 +765,12 @@
                       "format": "float"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [
@@ -907,10 +911,12 @@
                       "format": "float"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [
@@ -1001,10 +1007,12 @@
                       "format": "float"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [
@@ -1154,10 +1162,12 @@
                       "format": "float"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   },
                   "required": [

--- a/spec/apps/rails/doc/openapi.yaml
+++ b/spec/apps/rails/doc/openapi.yaml
@@ -416,8 +416,10 @@ paths:
                       format: float
                     created_at:
                       type: string
+                      format: date-time
                     updated_at:
                       type: string
+                      format: date-time
                   required:
                   - id
                   - name
@@ -486,8 +488,10 @@ paths:
                     format: float
                   created_at:
                     type: string
+                    format: date-time
                   updated_at:
                     type: string
+                    format: date-time
                 required:
                 - id
                 - name
@@ -584,8 +588,10 @@ paths:
                     format: float
                   created_at:
                     type: string
+                    format: date-time
                   updated_at:
                     type: string
+                    format: date-time
                 required:
                 - id
                 - name
@@ -650,8 +656,10 @@ paths:
                     format: float
                   created_at:
                     type: string
+                    format: date-time
                   updated_at:
                     type: string
+                    format: date-time
                 required:
                 - id
                 - name
@@ -752,8 +760,10 @@ paths:
                     format: float
                   created_at:
                     type: string
+                    format: date-time
                   updated_at:
                     type: string
+                    format: date-time
                 required:
                 - id
                 - name

--- a/spec/apps/rails/doc/smart/expected.yaml
+++ b/spec/apps/rails/doc/smart/expected.yaml
@@ -183,8 +183,10 @@ paths:
                     format: float
                   created_at:
                     type: string
+                    format: date-time
                   updated_at:
                     type: string
+                    format: date-time
                 required:
                   - id
                   - name
@@ -313,8 +315,10 @@ components:
           format: float
         created_at:
           type: string
+          format: date-time
         updated_at:
           type: string
+          format: date-time
       required:
         - id
         - name

--- a/spec/requests/rails_smart_merge_spec.rb
+++ b/spec/requests/rails_smart_merge_spec.rb
@@ -34,6 +34,8 @@ RSpec::OpenAPI.info = {
   },
 }
 
+RSpec::OpenAPI.formats_builder = ->(_example, key) { key.end_with?('_at') ? 'date-time' : nil }
+
 # Small subset of `rails_spec.rb` with slight changes
 RSpec.describe 'Tables', type: :request do
   describe '#index', openapi: { required_request_params: 'show_columns', operation_id: 'table-index' } do

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -27,6 +27,8 @@ RSpec::OpenAPI.info = {
   },
 }
 
+RSpec::OpenAPI.formats_builder = ->(_example, key) { key.end_with?('_at') ? 'date-time' : nil }
+
 RSpec::OpenAPI.security_schemes = {
   SecretApiKeyAuth: {
     type: 'apiKey',


### PR DESCRIPTION
This PR enhances the schema builder to allow <a href="https://swagger.io/docs/specification/v3_0/data-models/data-types/#string-formats">specifying custom formats for string parameters</a> in the OpenAPI schema.
The implementation introduces a new mechanism that can associate format information with specific keys in request and response data.