### PR TITLE
Fix psych  disallowedclass error in ruby 3.1

### DIFF
--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'yaml'
 require 'json'
+require 'date'
 
 # TODO: Support JSON
 class RSpec::OpenAPI::SchemaFile
@@ -24,7 +25,12 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    RSpec::OpenAPI::KeyTransformer.symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
+    RSpec::OpenAPI::KeyTransformer.symbolize(
+      YAML.safe_load(
+        File.read(@path),
+        permitted_classes: [Date],
+      ),
+    ) # this can also parse JSON
   end
 
   # @param [Hash] spec

--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'yaml'
 require 'json'
 require 'date'
+require 'time'
 
 # TODO: Support JSON
 class RSpec::OpenAPI::SchemaFile
@@ -28,7 +29,7 @@ class RSpec::OpenAPI::SchemaFile
     RSpec::OpenAPI::KeyTransformer.symbolize(
       YAML.safe_load(
         File.read(@path),
-        permitted_classes: [Date],
+        permitted_classes: [Date, Time],
       ),
     ) # this can also parse JSON
   end

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'date'
 
 RSpec.describe RSpec::OpenAPI::SchemaFile do
   describe '#read' do
@@ -20,7 +19,8 @@ RSpec.describe RSpec::OpenAPI::SchemaFile do
                   in: query
                   schema:
                     type: string
-                    example: 2020-01-02 # Unquoted date
+                    date: 2020-01-02 # Unquoted date
+                    time: 2025-06-10 01:47:28Z
       YAML
     end
 
@@ -34,7 +34,8 @@ RSpec.describe RSpec::OpenAPI::SchemaFile do
       expect do
         data = schema_file.send(:read)
       end.not_to raise_error(Psych::DisallowedClass)
-      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :example).to_s).to eq('2020-01-02')
+      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :date).to_s).to eq('2020-01-02')
+      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :time).to_s).to eq("2025-06-10 01:47:28 UTC")
     end
   end
 end

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'date'
+
+RSpec.describe RSpec::OpenAPI::SchemaFile do
+  describe '#read' do
+    let(:schema_content) do
+      <<~YAML
+        openapi: 3.0.0
+        info:
+          title: My API
+          version: 1.0.0
+        paths:
+          /:
+            get:
+              summary: A test endpoint
+              parameters:
+                - name: date
+                  in: query
+                  schema:
+                    type: string
+                    example: 2020-01-02 # Unquoted date
+      YAML
+    end
+
+    it 'deserializes unquoted dates as Date objects when Date is permitted' do
+      schema_file = RSpec::OpenAPI::SchemaFile.new('nonexistant/schema.yaml')
+
+      expect(File).to receive(:read).and_return(schema_content)
+      expect(File).to receive(:exist?).and_return(true)
+
+      data = nil
+      expect do
+        data = schema_file.send(:read)
+      end.not_to raise_error(Psych::DisallowedClass)
+      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :example).to_s).to eq('2020-01-02')
+    end
+  end
+end

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RSpec::OpenAPI::SchemaFile do
         data = schema_file.send(:read)
       end.not_to raise_error(Psych::DisallowedClass)
       expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :date).to_s).to eq('2020-01-02')
-      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :time).to_s).to eq("2025-06-10 01:47:28 UTC")
+      expect(data.dig(:paths, :/, :get, :parameters, 0, :schema, :time).to_s).to eq('2025-06-10 01:47:28 UTC')
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/exoego/rspec-openapi/issues/249 by adding `Date` to `permitted_classes` of `YAML.safe_load` in `RSpec::OpenAPI::SchemaFile#read`.

# Changes

- allow Date and Time when reading YAML schema files
- add regression test for SchemaFile

