### PR TITLE
Unwrap Rails' _json root from recorded JSON request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ responses:
   '400': { ... }
 ```
 
-Mixing `:single` (some tests) with `:multiple` (others) on the same endpoint also works for `requestBody` - 
+Mixing `:single` (some tests) with `:multiple` (others) on the same endpoint also works for `requestBody` -
 the merger up-converts the singular `example:` into the `examples:` map automatically
 (see [Merge Behavior with Mixed Modes](#merge-behavior-with-mixed-modes) below).
 
@@ -997,7 +997,7 @@ Existing RSpec plugins which have OpenAPI integration:
 ## Acknowledgements
 
 * Heavily inspired by [r7kamura/autodoc](https://github.com/r7kamura/autodoc)
-* Orignally created by [k0kubun](https://github.com/k0kubun) and the ownership was transferred
+* Originally created by [k0kubun](https://github.com/k0kubun) and the ownership was transferred
   to [exoego](https://github.com/exoego) in 2022-11-29.
 
 ## Releasing

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -79,8 +79,19 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
   # because ActionController::ParamsWrapper overwrites request_parameters
   def raw_request_params(request)
     original = request.delete_header('action_dispatch.request.request_parameters')
-    request.request_parameters
+    unwrap_json_root(request.request_parameters)
   ensure
     request.set_header('action_dispatch.request.request_parameters', original)
+  end
+
+  # Rails' default JSON parser wraps a body that isn't a Hash - a top-level array,
+  # string, number, and so on - as `{ _json: <body> }`, so `request_parameters`
+  # stops reflecting what the client actually sent.
+  # See ActionDispatch::Http::Parameters::DEFAULT_PARSERS
+  def unwrap_json_root(params)
+    return params unless params.is_a?(Hash) && params.size == 1
+
+    key, value = params.first
+    key.to_s == '_json' ? value : params
   end
 end

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -303,7 +303,7 @@ class << RSpec::OpenAPI::SchemaBuilder
   def build_example(value)
     return nil if value.nil?
 
-    adjust_params(value.dup)
+    adjust_value(value.dup)
   end
 
   def adjust_params(hash)

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -133,6 +133,11 @@ Rails.application.routes.draw do
     post '/example_mode_request_only_multi' => ->(_env) { [201, { 'Content-Type' => 'application/json' }, ['{"created":true}']] }
     post '/example_mode_request_body_none' => ->(_env) { [201, { 'Content-Type' => 'application/json' }, ['{"created":true}']] }
 
+    # Top-level (non-Hash) JSON request bodies, which Rails' default JSON parser wraps in `{ _json: ... }`.
+    post '/root_array_body' => ->(_env) { [201, { 'Content-Type' => 'application/json' }, ['{"created":true}']] }
+    post '/root_scalar_body' => ->(_env) { [201, { 'Content-Type' => 'application/json' }, ['{"created":true}']] }
+    post '/root_json_key' => ->(_env) { [201, { 'Content-Type' => 'application/json' }, ['{"created":true}']] }
+
     # Test route for nested arrays (key_transformer coverage)
     get '/nested_arrays_test' => ->(_env) { [200, { 'Content-Type' => 'application/json' }, ['{"items":[{"name":"first","tags":["a","b","c"]},{"name":"second","tags":["x","y","z"]}],"matrix":[[1,2],[3,4]]}']] }
 

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -3244,6 +3244,168 @@
         }
       }
     },
+    "/root_array_body": {
+      "post": {
+        "summary": "POST /root_array_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "priority"
+                  ]
+                }
+              },
+              "example": [
+                {
+                  "name": "ruby",
+                  "priority": 1
+                },
+                {
+                  "name": "rails",
+                  "priority": 2
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents an array body as an array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_json_key": {
+      "post": {
+        "summary": "POST /root_json_key",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "_json": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "_json",
+                  "name"
+                ]
+              },
+              "example": {
+                "_json": [
+                  "a",
+                  "b"
+                ],
+                "name": "ruby"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "leaves an object that merely contains a _json key alone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_scalar_body": {
+      "post": {
+        "summary": "POST /root_scalar_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              },
+              "example": "hello"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents a scalar body as a scalar",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/secret_items": {
       "get": {
         "summary": "index",

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -1989,6 +1989,106 @@ paths:
               schema:
                 type: string
               example: A RACK FOO
+  "/root_array_body":
+    post:
+      summary: POST /root_array_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  priority:
+                    type: integer
+                required:
+                - name
+                - priority
+            example:
+            - name: ruby
+              priority: 1
+            - name: rails
+              priority: 2
+      responses:
+        '201':
+          description: documents an array body as an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_json_key":
+    post:
+      summary: POST /root_json_key
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _json:
+                  type: array
+                  items:
+                    type: string
+                name:
+                  type: string
+              required:
+              - _json
+              - name
+            example:
+              _json:
+              - a
+              - b
+              name: ruby
+      responses:
+        '201':
+          description: leaves an object that merely contains a _json key alone
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_scalar_body":
+    post:
+      summary: POST /root_scalar_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+            example: hello
+      responses:
+        '201':
+          description: documents a scalar body as a scalar
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
   "/secret_items":
     get:
       summary: index

--- a/spec/apps/rails/doc/rspec_openapi_3.1.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.json
@@ -3291,6 +3291,168 @@
         }
       }
     },
+    "/root_array_body": {
+      "post": {
+        "summary": "POST /root_array_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "priority"
+                  ]
+                }
+              },
+              "example": [
+                {
+                  "name": "ruby",
+                  "priority": 1
+                },
+                {
+                  "name": "rails",
+                  "priority": 2
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents an array body as an array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_json_key": {
+      "post": {
+        "summary": "POST /root_json_key",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "_json": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "_json",
+                  "name"
+                ]
+              },
+              "example": {
+                "_json": [
+                  "a",
+                  "b"
+                ],
+                "name": "ruby"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "leaves an object that merely contains a _json key alone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_scalar_body": {
+      "post": {
+        "summary": "POST /root_scalar_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              },
+              "example": "hello"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents a scalar body as a scalar",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/secret_items": {
       "get": {
         "summary": "index",

--- a/spec/apps/rails/doc/rspec_openapi_3.1.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.yaml
@@ -2016,6 +2016,106 @@ paths:
               schema:
                 type: string
               example: A RACK FOO
+  "/root_array_body":
+    post:
+      summary: POST /root_array_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  priority:
+                    type: integer
+                required:
+                - name
+                - priority
+            example:
+            - name: ruby
+              priority: 1
+            - name: rails
+              priority: 2
+      responses:
+        '201':
+          description: documents an array body as an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_json_key":
+    post:
+      summary: POST /root_json_key
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _json:
+                  type: array
+                  items:
+                    type: string
+                name:
+                  type: string
+              required:
+              - _json
+              - name
+            example:
+              _json:
+              - a
+              - b
+              name: ruby
+      responses:
+        '201':
+          description: leaves an object that merely contains a _json key alone
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_scalar_body":
+    post:
+      summary: POST /root_scalar_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+            example: hello
+      responses:
+        '201':
+          description: documents a scalar body as a scalar
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
   "/secret_items":
     get:
       summary: index

--- a/spec/apps/rails/doc/rspec_openapi_3.2.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.json
@@ -3291,6 +3291,168 @@
         }
       }
     },
+    "/root_array_body": {
+      "post": {
+        "summary": "POST /root_array_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "priority"
+                  ]
+                }
+              },
+              "example": [
+                {
+                  "name": "ruby",
+                  "priority": 1
+                },
+                {
+                  "name": "rails",
+                  "priority": 2
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents an array body as an array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_json_key": {
+      "post": {
+        "summary": "POST /root_json_key",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "_json": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "_json",
+                  "name"
+                ]
+              },
+              "example": {
+                "_json": [
+                  "a",
+                  "b"
+                ],
+                "name": "ruby"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "leaves an object that merely contains a _json key alone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/root_scalar_body": {
+      "post": {
+        "summary": "POST /root_scalar_body",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              },
+              "example": "hello"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "documents a scalar body as a scalar",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "created": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "created"
+                  ]
+                },
+                "example": {
+                  "created": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/secret_items": {
       "get": {
         "summary": "index",

--- a/spec/apps/rails/doc/rspec_openapi_3.2.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.yaml
@@ -2016,6 +2016,106 @@ paths:
               schema:
                 type: string
               example: A RACK FOO
+  "/root_array_body":
+    post:
+      summary: POST /root_array_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  priority:
+                    type: integer
+                required:
+                - name
+                - priority
+            example:
+            - name: ruby
+              priority: 1
+            - name: rails
+              priority: 2
+      responses:
+        '201':
+          description: documents an array body as an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_json_key":
+    post:
+      summary: POST /root_json_key
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _json:
+                  type: array
+                  items:
+                    type: string
+                name:
+                  type: string
+              required:
+              - _json
+              - name
+            example:
+              _json:
+              - a
+              - b
+              name: ruby
+      responses:
+        '201':
+          description: leaves an object that merely contains a _json key alone
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
+  "/root_scalar_body":
+    post:
+      summary: POST /root_scalar_body
+      tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+            example: hello
+      responses:
+        '201':
+          description: documents a scalar body as a scalar
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: boolean
+                required:
+                - created
+              example:
+                created: true
   "/secret_items":
     get:
       summary: index

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -657,6 +657,27 @@ RSpec.describe 'Tags with array params', type: :request do
   end
 end
 
+# Rails' default JSON parser wraps a non-Hash body in `{ _json: ... }`, which is
+# an implementation detail clients never send.
+RSpec.describe 'Top-level JSON request body', type: :request do
+  it 'documents an array body as an array' do
+    post '/root_array_body', params: [{ name: 'ruby', priority: 1 }, { name: 'rails', priority: 2 }].to_json,
+                             headers: { 'CONTENT_TYPE' => 'application/json' }
+    expect(response.status).to eq(201)
+  end
+
+  it 'documents a scalar body as a scalar' do
+    post '/root_scalar_body', params: 'hello'.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+    expect(response.status).to eq(201)
+  end
+
+  it 'leaves an object that merely contains a _json key alone' do
+    post '/root_json_key', params: { _json: ['a', 'b'], name: 'ruby' }.to_json,
+                           headers: { 'CONTENT_TYPE' => 'application/json' }
+    expect(response.status).to eq(201)
+  end
+end
+
 # Test custom example_key override
 RSpec.describe 'Custom example_key', type: :request do
   describe 'GET /custom_example_key', openapi: { example_mode: :multiple, example_key: 'my_custom_key' } do


### PR DESCRIPTION
Rails' default JSON parser wraps a request body that isn't a Hash - a
top-level array, string, number, and so on - as `{ _json: <body> }`
(ActionDispatch::Http::Parameters::DEFAULT_PARSERS). Because the recorder
reads `request.request_parameters` verbatim, that internal wrapper leaked
into the generated document: a `POST` with a bare-array body was documented
as an object with a required `_json` array property, and the example was
`{ _json: [...] }` - a shape no client ever sends.

Unwrap the wrapper at the source, next to the existing ParamsWrapper
workaround, so both the schema and the example are fixed in one place. The
unwrap applies only when `_json` is the sole key, so an object that
genuinely carries a `_json` key alongside others is left untouched.

`build_example` assumed a Hash root and called `adjust_params`, which is
`transform_values!`; it now dispatches through `adjust_value` so an array
or scalar root works.

https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/actionpack/lib/action_dispatch/http/parameters.rb#L12-L17