### PR TITLE
Record branch coverage from the minitest runs too

### DIFF
--- a/.simplecov_spawn.rb
+++ b/.simplecov_spawn.rb
@@ -4,13 +4,20 @@ unless ENV['COVERAGE'] && ENV['COVERAGE'].empty?
   require 'simplecov'
   require 'simplecov-cobertura'
 
-  SimpleCov.at_fork.call(Process.pid)
-  SimpleCov.formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::CoberturaFormatter,
-  ])
-  SimpleCov.start do
+  # Configure before at_fork rather than in the start block below. at_fork's
+  # lambda calls SimpleCov.start itself, and once Coverage is running the mode
+  # is fixed, so asking for branches afterwards is too late. The runs spawned as
+  # `ruby -r./.simplecov_spawn` (the minitest ones) hit exactly that and were
+  # recording lines only, contributing no branch data at all.
+  SimpleCov.configure do
     enable_coverage :branch
     add_filter '/spec/'
     add_filter '/scripts/'
   end
+
+  SimpleCov.at_fork.call(Process.pid)
+  SimpleCov.formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::CoberturaFormatter,
+  ])
+  SimpleCov.start
 end

--- a/spec/integration_tests/rails_hook_error_test.rb
+++ b/spec/integration_tests/rails_hook_error_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require 'fileutils'
+require 'minitest/autorun'
+require File.expand_path('../apps/rails/config/environment', __dir__)
+
+OPENAPI_PATH = File.expand_path('../apps/rails/tmp/minitest_hook_error.yaml', __dir__)
+FileUtils.mkdir_p(File.dirname(OPENAPI_PATH))
+FileUtils.rm_f(OPENAPI_PATH)
+
+# `path` takes a proc resolved per example under Minitest too, not only RSpec.
+RSpec::OpenAPI.title = 'OpenAPI Documentation'
+RSpec::OpenAPI.path = ->(_example) { OPENAPI_PATH }
+RSpec::OpenAPI.request_headers = []
+RSpec::OpenAPI.response_headers = []
+
+class MinitestHookErrorTest < ActionDispatch::IntegrationTest
+  openapi!
+
+  test 'records a request whose schema is then made unbuildable' do
+    get '/invalid_responses'
+    assert_response 200
+  end
+end
+
+# after_run blocks run in reverse registration order, so this one runs before
+# the recorder rspec-openapi registered while it was loading. It swaps in a
+# response body the schema builder cannot handle, which is what makes the
+# recorder report an error rather than write a document.
+Minitest.after_run do
+  record = RSpec::OpenAPI.path_records[OPENAPI_PATH].last
+  raise 'OpenAPI record was not generated' unless record
+
+  RSpec::OpenAPI.path_records[OPENAPI_PATH] << RSpec::OpenAPI::Record.new(
+    **record.to_h, response_body: Object.new,
+  )
+end

--- a/spec/minitest/hook_error_spec.rb
+++ b/spec/minitest/hook_error_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'minitest integration, hook error handling' do
+  include SpecHelper
+
+  it 'reports the records it could not build' do
+    out, err, = minitest 'spec/integration_tests/rails_hook_error_test.rb', openapi: true, output: :yaml
+    expect(out + err).to include('RSpec::OpenAPI got errors building 1 requests')
+    expect(out + err).to include('type detection is not implemented for')
+  end
+end


### PR DESCRIPTION
Answering "are we even running minitest?" — yes, six spawned runs (three Rails, three Roda). But they were contributing **line coverage and no branch coverage at all**: 0 of the 27 library files they load carried branch data.

## Cause

`.simplecov_spawn.rb` asked for branch coverage inside the `SimpleCov.start` block, which sits below `SimpleCov.at_fork.call`. That lambda calls `SimpleCov.start` itself, and once `Coverage` is running its mode is fixed, so the request arrived too late.

The rspec runs were unaffected: they go through `scripts/rspec_with_simplecov`, which starts SimpleCov with branches on *before* `.simplecov_spawn` is loaded. Only the runs spawned as plain `ruby -r./.simplecov_spawn` — the minitest ones — hit it.

Configuring before `at_fork` fixes it. 23 of 27 files now carry branch data; the other 4 have no branches at all.

## Effect

| | master | this PR |
|---|---|---|
| branches measured | 446 | **456** |
| branches covered | 426 | **437** |
| lines with an uncovered branch | 20 | **19** |

Ten branches became visible. Most were already exercised — including the `require 'rspec/openapi/minitest_hooks'` that was being reported as never taken while minitest was plainly running through it, which is what makes this worth fixing beyond the number.

It also surfaced two branches in `minitest_hooks.rb` that nothing exercised, so a minitest run now covers them: it resolves `path` from a proc, and it appends a record the schema builder cannot handle so the `after_run` reporter has something to report. The rspec side already had the equivalent in `rspec_hook_error_spec`.

Note the headline percentage barely moves, because the denominator grew along with the numerator. The point is that the measurement is now honest about a sixth of the suite.

## Verified

- 15 spec files, 0 failures; every committed document regenerates byte for byte.
- Rubocop reports the same 4 pre-existing offenses as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when recorded requests cannot be converted into an OpenAPI document.
  - Error messages now identify how many requests could not be processed and include the underlying type-detection issue.

- **Tests**
  - Added coverage for Rails and Minitest hook failures.
  - Added validation for branch coverage in forked test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->