### PR TITLE
Add documentation comments to ExchangeRecorder modules

### DIFF
--- a/lib/rspec/openapi/exchange_recorder.rb
+++ b/lib/rspec/openapi/exchange_recorder.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+# Records every request/response exchange issued in an example so that
+# the exchange matching `request_pattern` can be looked up afterwards.
 module RSpec::OpenAPI::ExchangeRecorder
   THREAD_KEY = :rspec_openapi_exchanges
   VERBS = [:get, :post, :put, :patch, :delete, :head, :options].freeze
 
+  # Wraps HTTP verb methods to capture the exchange right after each request.
   module VerbTracking
     VERBS.each do |verb|
       define_method(verb) do |*args, &block|


### PR DESCRIPTION
Adds top-level documentation comments to `RSpec::OpenAPI::ExchangeRecorder` and its nested `VerbTracking` module.

This resolves the `Style/Documentation` offenses reported by code scanning alerts:
- https://github.com/exoego/rspec-openapi/security/code-scanning/934
- https://github.com/exoego/rspec-openapi/security/code-scanning/935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comments explaining the exchange recorder’s purpose and HTTP verb interception behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->