### PR TITLE
Speed up the spec suite by about 20 percent

### DIFF
--- a/.simplecov_spawn.rb
+++ b/.simplecov_spawn.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-unless ENV['COVERAGE'] && ENV['COVERAGE'].empty?
+# Coverage is opt-in: it costs roughly a quarter of each spawned run, so only
+# instrument when COVERAGE is set to something non-empty, as the one CI job
+# that uploads to codecov does.
+unless ENV.fetch('COVERAGE', '').empty?
   require 'simplecov'
   require 'simplecov-cobertura'
 

--- a/scripts/parallel_rspec
+++ b/scripts/parallel_rspec
@@ -9,11 +9,18 @@
 # Ruby. Run serially it leaves every core but one idle. No two spec files write
 # the same document, which is what makes running them side by side safe.
 #
+# Booting a worker (bundler, rspec, spec_helper, SimpleCov when enabled) costs
+# around a second, so spawning one process per spec file wastes more time than
+# the parallelism buys back. Instead the files are packed into one batch per
+# worker up front, and each worker runs its whole batch in a single rspec
+# process. Files in a batch run sequentially, so sharing a batch never violates
+# the one-writer-per-document constraint above.
+#
 #   bundle exec scripts/parallel_rspec                    # one worker per core
 #   RSPEC_WORKERS=1 bundle exec scripts/parallel_rspec    # back to a serial run
 #   bundle exec scripts/parallel_rspec spec/rspec         # a subset
 #
-# Output is buffered per file and printed when that file finishes, so the
+# Output is buffered per worker and printed when that worker finishes, so the
 # workers do not interleave their reports. Use plain `rspec` when you want the
 # usual streaming output or `--only-failures`, which reads the .rspec_status
 # that only a serial run maintains.
@@ -35,60 +42,95 @@ def spec_files(args)
   config.files_to_run.uniq
 end
 
-# Rough cost of a spec file: each of these calls boots an app in a child process
-# and they dominate the run time. Starting with the most expensive file keeps
-# the workers busy to the end. A bad guess only costs some scheduling.
-def spawn_count(file)
-  File.read(file).scan(/^\s*(?:rspec|rspec_capture|minitest)[\s(]/).size
+# Rough cost of a spec file, in units of one spawned app boot. Each rspec /
+# rspec_capture / minitest call boots an app in a child process. Booting the
+# app dominates a child, so every spawn costs about one unit, with a mild
+# bump for how much spec the child then runs. A bad guess only costs some
+# scheduling.
+def spawn_cost(file)
+  dir = File.expand_path('..', __dir__)
+  File.read(file).scan(/\b(?:rspec|rspec_capture|minitest)[\s(]+'([^']+)'/).sum do |(spawned)|
+    path = File.join(dir, spawned)
+    1.0 + (File.exist?(path) ? File.size(path) / 100_000.0 : 0.0)
+  end
+end
+
+# Every worker runs alongside the app process it spawns, and on Apple silicon
+# pushing that pairing onto the efficiency cores slows the whole run down, so
+# default to one worker per performance core there.
+def default_workers
+  return Etc.nprocessors unless RUBY_PLATFORM.include?('darwin')
+
+  begin
+    Integer(`sysctl -n hw.perflevel0.physicalcpu`)
+  rescue StandardError
+    Etc.nprocessors
+  end
 end
 
 args = ARGV.dup
-files = spec_files(args).sort_by { |file| [-spawn_count(file), file] }
+files = spec_files(args)
 abort('No spec files found') if files.empty?
 
 flags = args.reject { |arg| File.exist?(arg.sub(/[\[:]\d.*\z/, '')) }
-workers = Integer(ENV.fetch('RSPEC_WORKERS') { Etc.nprocessors }).clamp(1, files.size)
+workers = Integer(ENV.fetch('RSPEC_WORKERS') { default_workers }).clamp(1, files.size)
+
+# Pack the files into one batch per worker, assigning the most expensive file
+# to the least loaded batch. The small constant is the per-file load cost, so
+# the many nearly-free files do not all pile into one batch.
+batches = Array.new(workers) { { files: [], cost: 0.0 } }
+costs = files.to_h { |file| [file, spawn_cost(file)] }
+files.sort_by { |file| [-costs[file], file] }.each do |file|
+  batch = batches.min_by { |b| b[:cost] }
+  batch[:files] << file
+  batch[:cost] += costs[file] + 0.1
+end
+batches.reject! { |batch| batch[:files].empty? }
+
 # Route the workers through the SimpleCov wrapper rather than rspec directly.
 # schema_file_spec, scheme_merger_spec and shared_extractor_spec exercise the
 # library in the worker itself rather than in a spawned app, so without this
-# nothing they cover is recorded. The wrapper and .simplecov_spawn both no-op
-# unless COVERAGE is set, so the other jobs are unaffected.
+# nothing they cover is recorded. The wrapper and .simplecov_spawn no-op when
+# COVERAGE is unset or empty, so the other jobs are unaffected.
 rspec = File.expand_path('rspec_with_simplecov', __dir__)
 
 status_dir = File.join(Dir.tmpdir, "rspec-openapi-parallel-#{Process.pid}")
 FileUtils.mkdir_p(status_dir)
 at_exit { FileUtils.remove_entry(status_dir, true) }
 
-puts "Running #{files.size} spec files over #{workers} workers"
+puts "Running #{files.size} spec files over #{batches.size} workers"
 started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-queue = files.dup
 running = {}
 failed = []
 
-until queue.empty? && running.empty?
-  while running.size < workers && !queue.empty?
-    file = queue.shift
-    log = File.join(status_dir, "#{running.size}-#{File.basename(file)}.log")
-    # Each worker keeps its own example status file: RSpec rewrites the whole
-    # file on exit, so sharing one would let the workers corrupt each other's.
-    env = { 'RSPEC_STATUS_FILE' => File.join(status_dir, "#{File.basename(file)}.status") }
-    pid = Process.spawn(env, RbConfig.ruby, rspec, '-r./.simplecov_spawn', *flags, file, out: log, err: log)
-    running[pid] = [file, log]
-  end
+batches.each_with_index do |batch, index|
+  log = File.join(status_dir, "worker-#{index}.log")
+  # Each worker keeps its own example status file: RSpec rewrites the whole
+  # file on exit, so sharing one would let the workers corrupt each other's.
+  env = { 'RSPEC_STATUS_FILE' => File.join(status_dir, "worker-#{index}.status") }
+  pid = Process.spawn(env, RbConfig.ruby, rspec, '-r./.simplecov_spawn', *flags, *batch[:files], out: log, err: log)
+  running[pid] = [batch, log]
+end
 
+until running.empty?
   pid, status = Process.wait2
-  file, log = running.delete(pid)
-  next unless file
+  batch, log = running.delete(pid)
+  next unless batch
 
-  puts "\n===== #{file} ====="
+  puts "\n===== #{batch[:files].map { |file| file.sub("#{Dir.pwd}/", '') }.join(' ')} ====="
   print File.read(log)
-  failed << file unless status.success?
+  next if status.success?
+
+  # RSpec lists each failure as a `rspec ./spec/...:12` rerun line; recover the
+  # failing files from those, falling back to blaming the whole batch.
+  from_log = File.read(log).scan(%r{^rspec (?:\./)?(\S+\.rb)}).flatten.uniq
+  failed.concat(from_log.empty? ? batch[:files] : from_log)
 end
 
 elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 puts format("\n===== %<files>d spec files in %<elapsed>.1fs over %<workers>d workers =====",
-            files: files.size, elapsed: elapsed, workers: workers,)
+            files: files.size, elapsed: elapsed, workers: batches.size,)
 
 unless failed.empty?
   puts "Failed spec files:\n#{failed.map { |file| "  #{file}" }.join("\n")}"

--- a/scripts/rspec_with_simplecov
+++ b/scripts/rspec_with_simplecov
@@ -32,7 +32,9 @@ begin
   old_verbose = $VERBOSE
   $VERBOSE = false
 
-  unless (ENV.fetch('COVERAGE', nil) && ENV['COVERAGE'].empty?) || RUBY_VERSION < '1.9.3'
+  # Coverage is opt-in: only instrument when COVERAGE is set to something
+  # non-empty, as the one CI job that uploads to codecov does.
+  if !ENV.fetch('COVERAGE', '').empty? && RUBY_VERSION >= '1.9.3'
     require 'simplecov'
 
     SimpleCov.start do

--- a/spec/minitest/rails_json_spec.rb
+++ b/spec/minitest/rails_json_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'rails integration minitest, json output' do
+  include SpecHelper
+
+  describe 'json' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/minitest_openapi.json', repo_root)
+    end
+
+    it 'generates the same spec/apps/rails/doc/minitest_openapi.json' do
+      org_json = JSON.parse(File.read(openapi_path))
+      minitest 'spec/integration_tests/rails_test.rb', openapi: true, output: :json
+      new_json = JSON.parse(File.read(openapi_path))
+      expect(new_json).to eq org_json
+    end
+  end
+end

--- a/spec/minitest/rails_no_openapi_spec.rb
+++ b/spec/minitest/rails_no_openapi_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'rails integration minitest, without OpenAPI generation' do
+  include SpecHelper
+
+  describe 'with disabled OpenAPI generation' do
+    it 'can run tests' do
+      minitest 'spec/integration_tests/rails_test.rb'
+    end
+  end
+end

--- a/spec/minitest/rails_spec.rb
+++ b/spec/minitest/rails_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'json'
-require 'pry'
 
 RSpec.describe 'rails integration minitest' do
   include SpecHelper
@@ -18,25 +16,6 @@ RSpec.describe 'rails integration minitest' do
       minitest 'spec/integration_tests/rails_test.rb', openapi: true, output: :yaml
       new_yaml = YAML.safe_load(File.read(openapi_path))
       expect(new_yaml).to eq org_yaml
-    end
-  end
-
-  describe 'json' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/minitest_openapi.json', repo_root)
-    end
-
-    it 'generates the same spec/apps/rails/doc/minitest_openapi.json' do
-      org_yaml = JSON.parse(File.read(openapi_path))
-      minitest 'spec/integration_tests/rails_test.rb', openapi: true, output: :json
-      new_yaml = JSON.parse(File.read(openapi_path))
-      expect(new_yaml).to eq org_yaml
-    end
-  end
-
-  describe 'with disabled OpenAPI generation' do
-    it 'can run tests' do
-      minitest 'spec/integration_tests/rails_test.rb'
     end
   end
 end

--- a/spec/rspec/hanami_spec.rb
+++ b/spec/rspec/hanami_spec.rb
@@ -5,7 +5,6 @@ return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
 require 'spec_helper'
 require 'yaml'
 require 'json'
-require 'pry'
 
 RSpec.describe 'hanami request spec' do
   include SpecHelper

--- a/spec/rspec/multi_request_same_path_spec.rb
+++ b/spec/rspec/multi_request_same_path_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe 'multi-request same path regression' do
     expect(new_yaml).to eq org_yaml
   end
 
+  # The examples below read the document the first example regenerated (equal
+  # to the committed fixture, as it asserts) rather than spawning another run.
+
   it 'keeps DELETE metadata when the example performs a follow-up GET' do
-    rspec 'spec/requests/rails_multi_request_same_path_spec.rb', openapi: true, output: :yaml
     operation = YAML.safe_load(File.read(openapi_path)).dig('paths', '/widgets/{id}')
 
     delete_op = operation['delete']
@@ -38,7 +40,6 @@ RSpec.describe 'multi-request same path regression' do
   end
 
   it 'matches multi-segment path templates with several {param} placeholders' do
-    rspec 'spec/requests/rails_multi_request_same_path_spec.rb', openapi: true, output: :yaml
     operation = YAML.safe_load(File.read(openapi_path)).dig('paths', '/orgs/{org_id}/members/{user_id}')
 
     delete_op = operation['delete']
@@ -55,25 +56,5 @@ RSpec.describe 'multi-request same path regression' do
     get_op = operation['get']
     expect(get_op['summary']).to eq('Get an org member')
     expect(get_op['responses'].keys).to contain_exactly('200', '404')
-  end
-
-  it 'applies request_pattern over the Rack::Test (roda) path too' do
-    roda_path = File.expand_path('spec/apps/roda/doc/request_pattern.yaml', repo_root)
-    rspec 'spec/requests/roda_request_pattern_spec.rb', openapi: true, output: :yaml
-    operation = YAML.safe_load(File.read(roda_path)).dig('paths', '/widgets/1')
-
-    expect(operation.keys).to eq(['delete'])
-    expect(operation.dig('delete', 'summary')).to eq('Delete a widget')
-    expect(operation.dig('delete', 'responses').keys).to eq(['200'])
-  end
-
-  it 'fails fast with a clear message for an unparseable or unmatched request_pattern' do
-    out, err, status = rspec_capture 'spec/requests/rails_request_pattern_error_spec.rb', openapi: true, output: :yaml
-    combined = out + err
-
-    expect(status.success?).to eq(false)
-    expect(combined).to match(/Invalid request_pattern "not-a-valid-pattern"/)
-    expect(combined).to match(%r{request_pattern "GET /never/called" did not match})
-    expect(combined).to match(/Recorded requests: \(no requests were recorded\)/)
   end
 end

--- a/spec/rspec/rails_config_errors_spec.rb
+++ b/spec/rspec/rails_config_errors_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, configuration errors' do
+  include SpecHelper
+
+  describe 'an invalid example_mode' do
+    it 'aborts the example naming both the value and the example' do
+      out, err, status = rspec_capture 'spec/requests/rails_invalid_example_mode_spec.rb', openapi: true, output: :yaml
+      expect(status.success?).to eq(false)
+      message = 'example_mode must be a Symbol/String in [:none, :single, :multiple] or a Hash with ' \
+                ':request/:response keys, got 42 (example: invalid example_mode '
+      expect(out + err).to include("#{message}aborts on a bare value that is not a mode)")
+      expect(out + err).to include("#{message}aborts on a per-side value that is not a mode)")
+    end
+  end
+
+  describe 'a per-directory config file that raises' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/broken_config/openapi.yaml', repo_root)
+    end
+
+    it 'warns and still writes the document' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      out, = rspec 'spec/requests/rails_broken_config_spec.rb', openapi: true, output: :yaml
+      expect(out).to include('WARNING: Unable to load')
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+  end
+end

--- a/spec/rspec/rails_config_spec.rb
+++ b/spec/rspec/rails_config_spec.rb
@@ -30,45 +30,6 @@ RSpec.describe 'rails request spec, configuration' do
     end
   end
 
-  describe 'enable_example turned off' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/no_example/openapi.yaml', repo_root)
-    end
-
-    it 'generates the committed no_example/openapi.yaml' do
-      org_yaml = YAML.safe_load(File.read(openapi_path))
-      rspec 'spec/requests/rails_no_example_spec.rb', openapi: true, output: :yaml
-      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
-    end
-
-    it 'leaves example values out of parameters and the request body' do
-      expect(File.read(openapi_path)).not_to include('example:')
-    end
-  end
-
-  describe 'controller specs as an example type' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/controller/openapi.yaml', repo_root)
-    end
-
-    it 'generates the committed controller/openapi.yaml' do
-      org_yaml = YAML.safe_load(File.read(openapi_path))
-      rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
-      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
-    end
-  end
-
-  describe 'an invalid example_mode' do
-    it 'aborts the example naming both the value and the example' do
-      out, err, status = rspec_capture 'spec/requests/rails_invalid_example_mode_spec.rb', openapi: true, output: :yaml
-      expect(status.success?).to eq(false)
-      message = 'example_mode must be a Symbol/String in [:none, :single, :multiple] or a Hash with ' \
-                ':request/:response keys, got 42 (example: invalid example_mode '
-      expect(out + err).to include("#{message}aborts on a bare value that is not a mode)")
-      expect(out + err).to include("#{message}aborts on a per-side value that is not a mode)")
-    end
-  end
-
   describe 'DEBUG in the environment' do
     let(:openapi_path) do
       File.expand_path('spec/apps/rails/doc/config/openapi.yaml', repo_root)
@@ -79,19 +40,6 @@ RSpec.describe 'rails request spec, configuration' do
     it 'records the same document as a run without it' do
       org_yaml = YAML.safe_load(File.read(openapi_path))
       rspec 'spec/requests/rails_config_spec.rb', openapi: true, output: :yaml, debug: true
-      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
-    end
-  end
-
-  describe 'a per-directory config file that raises' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/broken_config/openapi.yaml', repo_root)
-    end
-
-    it 'warns and still writes the document' do
-      org_yaml = YAML.safe_load(File.read(openapi_path))
-      out, = rspec 'spec/requests/rails_broken_config_spec.rb', openapi: true, output: :yaml
-      expect(out).to include('WARNING: Unable to load')
       expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
     end
   end

--- a/spec/rspec/rails_config_variants_spec.rb
+++ b/spec/rspec/rails_config_variants_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, configuration variants' do
+  include SpecHelper
+
+  describe 'enable_example turned off' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/no_example/openapi.yaml', repo_root)
+    end
+
+    it 'generates the committed no_example/openapi.yaml' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_no_example_spec.rb', openapi: true, output: :yaml
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+
+    it 'leaves example values out of parameters and the request body' do
+      expect(File.read(openapi_path)).not_to include('example:')
+    end
+  end
+
+  describe 'controller specs as an example type' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/controller/openapi.yaml', repo_root)
+    end
+
+    it 'generates the committed controller/openapi.yaml' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+  end
+end

--- a/spec/rspec/rails_merge_description_preserve_spec.rb
+++ b/spec/rspec/rails_merge_description_preserve_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, description preservation' do
+  include SpecHelper
+
+  describe 'description preservation with example_mode :none' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/description_preserve/openapi.yaml', repo_root)
+    end
+
+    let(:expected_path) do
+      File.expand_path('spec/apps/rails/doc/description_preserve/expected.yaml', repo_root)
+    end
+
+    it 'preserves existing descriptions when example_mode is :none but overwrites with normal mode' do
+      original_source = File.read(openapi_path)
+      begin
+        rspec 'spec/requests/rails_description_preserve_spec.rb', openapi: true, output: :yaml
+        new_yaml = YAML.safe_load(File.read(openapi_path))
+        expected_yaml = YAML.safe_load(File.read(expected_path))
+        expect(new_yaml).to eq expected_yaml
+      ensure
+        File.write(openapi_path, original_source)
+      end
+    end
+  end
+end

--- a/spec/rspec/rails_merge_smart_spec.rb
+++ b/spec/rspec/rails_merge_smart_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, smart merge' do
+  include SpecHelper
+
+  describe 'smart merge' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/smart/openapi.yaml', repo_root)
+    end
+
+    let(:expected_path) do
+      File.expand_path('spec/apps/rails/doc/smart/expected.yaml', repo_root)
+    end
+
+    it 'updates the spec/apps/rails/doc/smart/openapi.yaml as same as in expected.yaml' do
+      original_source = File.read(openapi_path)
+      begin
+        rspec 'spec/requests/rails_smart_merge_spec.rb', openapi: true, output: :yaml
+        new_yaml = YAML.safe_load(File.read(openapi_path))
+        expected_yaml = YAML.safe_load(File.read(expected_path))
+        expect(new_yaml).to eq expected_yaml
+      ensure
+        File.write(openapi_path, original_source)
+      end
+    end
+  end
+end

--- a/spec/rspec/rails_merge_spec.rb
+++ b/spec/rspec/rails_merge_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'json'
-require 'pry'
 
 RSpec.describe 'rails request spec, merging into an existing document' do
   include SpecHelper
@@ -30,50 +28,6 @@ RSpec.describe 'rails request spec, merging into an existing document' do
         expect(new_yaml).to eq expected_yaml
       ensure
         File.write(input_path, original_source)
-      end
-    end
-  end
-
-  describe 'smart merge' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/smart/openapi.yaml', repo_root)
-    end
-
-    let(:expected_path) do
-      File.expand_path('spec/apps/rails/doc/smart/expected.yaml', repo_root)
-    end
-
-    it 'updates the spec/apps/rails/doc/smart/openapi.yaml as same as in expected.yaml' do
-      original_source = File.read(openapi_path)
-      begin
-        rspec 'spec/requests/rails_smart_merge_spec.rb', openapi: true, output: :yaml
-        new_yaml = YAML.safe_load(File.read(openapi_path))
-        expected_yaml = YAML.safe_load(File.read(expected_path))
-        expect(new_yaml).to eq expected_yaml
-      ensure
-        File.write(openapi_path, original_source)
-      end
-    end
-  end
-
-  describe 'description preservation with example_mode :none' do
-    let(:openapi_path) do
-      File.expand_path('spec/apps/rails/doc/description_preserve/openapi.yaml', repo_root)
-    end
-
-    let(:expected_path) do
-      File.expand_path('spec/apps/rails/doc/description_preserve/expected.yaml', repo_root)
-    end
-
-    it 'preserves existing descriptions when example_mode is :none but overwrites with normal mode' do
-      original_source = File.read(openapi_path)
-      begin
-        rspec 'spec/requests/rails_description_preserve_spec.rb', openapi: true, output: :yaml
-        new_yaml = YAML.safe_load(File.read(openapi_path))
-        expected_yaml = YAML.safe_load(File.read(expected_path))
-        expect(new_yaml).to eq expected_yaml
-      ensure
-        File.write(openapi_path, original_source)
       end
     end
   end

--- a/spec/rspec/rails_openapi_version_3_2_spec.rb
+++ b/spec/rspec/rails_openapi_version_3_2_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+require 'json'
+
+RSpec.describe 'rails request spec, OpenAPI 3.2' do
+  include SpecHelper
+
+  describe 'OpenAPI 3.2 output' do
+    let(:yaml_path) do
+      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2.yaml', repo_root)
+    end
+
+    let(:json_path) do
+      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2.json', repo_root)
+    end
+
+    # Matches the 3.1 fixture except for the version and `/stream` (itemSchema
+    # here vs a string schema on 3.0/3.1). Committed to track 3.2 output too.
+    it 'generates the 3.2 fixture (yaml and json)' do
+      org_yaml = YAML.safe_load(File.read(yaml_path))
+      org_json = JSON.parse(File.read(json_path))
+      rspec 'spec/requests/rails_spec.rb', openapi: true, output: :both, openapi_version: '3.2.0'
+      new_yaml = YAML.safe_load(File.read(yaml_path))
+      new_json = JSON.parse(File.read(json_path))
+      expect(new_yaml).to eq org_yaml
+      expect(new_json).to eq org_json
+      expect(new_yaml).to eq new_json
+    end
+
+    it 'emits 3.2.0' do
+      expect(YAML.safe_load(File.read(yaml_path))['openapi']).to eq('3.2.0')
+    end
+  end
+end

--- a/spec/rspec/rails_openapi_version_features_spec.rb
+++ b/spec/rspec/rails_openapi_version_features_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, version-specific features' do
+  include SpecHelper
+
+  describe 'OpenAPI 3.2 HTTP methods (query / additionalOperations)' do
+    let(:yaml_path) do
+      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2_methods.yaml', repo_root)
+    end
+
+    # The request spec is a no-op on Rails < 7.1 (fixture unchanged, so this
+    # trivially holds); on 7.1+ it is regenerated and checked.
+    it 'records the query field and additionalOperations map' do
+      org_yaml = YAML.safe_load(File.read(yaml_path))
+      rspec 'spec/requests/rails_3_2_methods_spec.rb', openapi: true, output: :yaml
+      new_yaml = YAML.safe_load(File.read(yaml_path))
+      expect(new_yaml).to eq org_yaml
+    end
+  end
+
+  describe 'OpenAPI 3.2 streaming media types (itemSchema)' do
+    let(:yaml_path) do
+      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2_streaming.yaml', repo_root)
+    end
+
+    it 'records json-seq and SSE streams as itemSchema' do
+      org_yaml = YAML.safe_load(File.read(yaml_path))
+      rspec 'spec/requests/rails_3_2_streaming_spec.rb', openapi: true, output: :yaml
+      new_yaml = YAML.safe_load(File.read(yaml_path))
+      expect(new_yaml).to eq org_yaml
+    end
+  end
+
+  describe 'unsupported OpenAPI version' do
+    it 'aborts the run with a validation message' do
+      out, err, status = rspec_capture 'spec/requests/rails_invalid_version_spec.rb', openapi: true, output: :yaml
+      expect(status.success?).to eq(false)
+      # RSpec reports the load-time ArgumentError on stdout; warnings go to stderr.
+      expect(out + err).to match(/Unsupported OpenAPI version/)
+    end
+  end
+end

--- a/spec/rspec/rails_openapi_version_spec.rb
+++ b/spec/rspec/rails_openapi_version_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 require 'yaml'
 require 'json'
-require 'pry'
 
 RSpec.describe 'rails request spec, per OpenAPI version' do
   include SpecHelper
@@ -58,70 +57,6 @@ RSpec.describe 'rails request spec, per OpenAPI version' do
       expect(schema['openapi']).to eq('3.1.1')
       expect(deep_keys(schema)).not_to include('nullable')
       expect(collect_types(schema)).to include(['string', 'null'])
-    end
-  end
-
-  describe 'OpenAPI 3.2 output' do
-    let(:yaml_path) do
-      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2.yaml', repo_root)
-    end
-
-    let(:json_path) do
-      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2.json', repo_root)
-    end
-
-    # Matches the 3.1 fixture except for the version and `/stream` (itemSchema
-    # here vs a string schema on 3.0/3.1). Committed to track 3.2 output too.
-    it 'generates the 3.2 fixture (yaml and json)' do
-      org_yaml = YAML.safe_load(File.read(yaml_path))
-      org_json = JSON.parse(File.read(json_path))
-      rspec 'spec/requests/rails_spec.rb', openapi: true, output: :both, openapi_version: '3.2.0'
-      new_yaml = YAML.safe_load(File.read(yaml_path))
-      new_json = JSON.parse(File.read(json_path))
-      expect(new_yaml).to eq org_yaml
-      expect(new_json).to eq org_json
-      expect(new_yaml).to eq new_json
-    end
-
-    it 'emits 3.2.0' do
-      expect(YAML.safe_load(File.read(yaml_path))['openapi']).to eq('3.2.0')
-    end
-  end
-
-  describe 'OpenAPI 3.2 HTTP methods (query / additionalOperations)' do
-    let(:yaml_path) do
-      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2_methods.yaml', repo_root)
-    end
-
-    # The request spec is a no-op on Rails < 7.1 (fixture unchanged, so this
-    # trivially holds); on 7.1+ it is regenerated and checked.
-    it 'records the query field and additionalOperations map' do
-      org_yaml = YAML.safe_load(File.read(yaml_path))
-      rspec 'spec/requests/rails_3_2_methods_spec.rb', openapi: true, output: :yaml
-      new_yaml = YAML.safe_load(File.read(yaml_path))
-      expect(new_yaml).to eq org_yaml
-    end
-  end
-
-  describe 'OpenAPI 3.2 streaming media types (itemSchema)' do
-    let(:yaml_path) do
-      File.expand_path('spec/apps/rails/doc/rspec_openapi_3.2_streaming.yaml', repo_root)
-    end
-
-    it 'records json-seq and SSE streams as itemSchema' do
-      org_yaml = YAML.safe_load(File.read(yaml_path))
-      rspec 'spec/requests/rails_3_2_streaming_spec.rb', openapi: true, output: :yaml
-      new_yaml = YAML.safe_load(File.read(yaml_path))
-      expect(new_yaml).to eq org_yaml
-    end
-  end
-
-  describe 'unsupported OpenAPI version' do
-    it 'aborts the run with a validation message' do
-      out, err, status = rspec_capture 'spec/requests/rails_invalid_version_spec.rb', openapi: true, output: :yaml
-      expect(status.success?).to eq(false)
-      # RSpec reports the load-time ArgumentError on stdout; warnings go to stderr.
-      expect(out + err).to match(/Unsupported OpenAPI version/)
     end
   end
 end

--- a/spec/rspec/rails_spec.rb
+++ b/spec/rspec/rails_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 require 'yaml'
 require 'json'
-require 'pry'
 
 RSpec.describe 'rails request spec' do
   include SpecHelper

--- a/spec/rspec/request_pattern_spec.rb
+++ b/spec/rspec/request_pattern_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'request_pattern selector' do
+  include SpecHelper
+
+  it 'applies request_pattern over the Rack::Test (roda) path too' do
+    roda_path = File.expand_path('spec/apps/roda/doc/request_pattern.yaml', repo_root)
+    rspec 'spec/requests/roda_request_pattern_spec.rb', openapi: true, output: :yaml
+    operation = YAML.safe_load(File.read(roda_path)).dig('paths', '/widgets/1')
+
+    expect(operation.keys).to eq(['delete'])
+    expect(operation.dig('delete', 'summary')).to eq('Delete a widget')
+    expect(operation.dig('delete', 'responses').keys).to eq(['200'])
+  end
+
+  it 'fails fast with a clear message for an unparseable or unmatched request_pattern' do
+    out, err, status = rspec_capture 'spec/requests/rails_request_pattern_error_spec.rb', openapi: true, output: :yaml
+    combined = out + err
+
+    expect(status.success?).to eq(false)
+    expect(combined).to match(/Invalid request_pattern "not-a-valid-pattern"/)
+    expect(combined).to match(%r{request_pattern "GET /never/called" did not match})
+    expect(combined).to match(/Recorded requests: \(no requests were recorded\)/)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,11 @@ module SpecHelper
   #   :openapi_version pins the document version, :debug turns on rspec-openapi's
   #   own diagnostics. All of them are read while the child boots, which is why
   #   they travel as environment rather than as configuration in the spec.
+  #
+  # The child runs the current Ruby directly rather than through `bundle exec`,
+  # which would boot a whole extra Ruby process per spawn just to set up an
+  # environment that `require 'bundler/setup'` (in scripts/rspec_with_simplecov,
+  # or injected below for plain ruby) recreates from the Gemfile in the cwd.
   def within_test_run(*args, command:, **options)
     env = {
       'OPENAPI' => ('1' if options[:openapi]),
@@ -51,9 +56,10 @@ module SpecHelper
       'OPENAPI_VERSION' => options[:openapi_version],
       'DEBUG' => ('1' if options[:debug]),
     }.compact
+    argv = command == 'ruby' ? ['-rbundler/setup'] : [command]
     Bundler.public_send(Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env) do
       Dir.chdir(repo_root) do
-        yield [env, 'bundle', 'exec', command, '-r./.simplecov_spawn', *args]
+        yield [env, RbConfig.ruby, *argv, '-r./.simplecov_spawn', *args]
       end
     end
   end


### PR DESCRIPTION
## Summary

The suite is a queue of child processes that each boot a Rails, Hanami or Roda app. This PR attacks the three places that time actually goes.

* **Batch spec files into one rspec process per worker.** Booting a worker (bundler, rspec, spec_helper) costs about a second, so one process per spec file wasted more than the parallelism bought. `scripts/parallel_rspec` now packs files into one batch per worker and runs each batch in a single rspec process. Files in a batch run sequentially, so the one-writer-per-document constraint is preserved. On CI this drops worker boots from 17 to 4.
* **Split the heavy outer spec files by fixture ownership.** The wall clock was pinned by files holding many app-spawning groups (`rails_config_spec.rb`, `minitest/rails_spec.rb`, `rails_openapi_version_spec.rb`, `rails_merge_spec.rb`, `multi_request_same_path_spec.rb`). Each split file owns fixtures no other file writes. The read-only examples in `multi_request_same_path_spec.rb` no longer re-spawn the same inner run twice.
* **Drop the `bundle exec` layer from child spawns.** Each spawn booted a whole extra Ruby process just to set up an environment that `require 'bundler/setup'` recreates from the Gemfile.
* **Make coverage opt-in.** The SimpleCov wrappers ran unless `COVERAGE` was set to an empty string, a convention inherited from the rspec-core script they were copied from. CI sets `COVERAGE` explicitly on every row, so only local runs paid the ~25 percent instrumentation cost by accident. Coverage now runs only when `COVERAGE` is non-empty. The codecov row is unaffected and still reports the same numbers (Line 100.0%, Branch 95.97%).
* On Apple silicon the default worker count is now the performance-core count. Pushing a worker and its child onto the efficiency cores measured slower than leaving them idle.

## Measurements

Interleaved runs on an M-series MacBook (8P+4E), 3 rounds each, `rm -rf coverage` before every coverage run:

| mode | master | this PR | change |
|---|---|---|---|
| `COVERAGE=''` (like for like) | 10.0s | 8.0–8.2s | −20% |
| `COVERAGE=coverage` (like for like) | 11.0s | 8.6–8.8s | −21% |
| default local command | 11.0s | 8.0s | −27% |

All 26 spec files pass in every configuration, and the coverage report from the `COVERAGE=coverage` run is byte-identical in totals to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)