### PR TITLE
fix: skip recording an example that issues no request

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -11,6 +11,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
   def build(context, example:, extractor:)
     request, response = select_request_response(context, example, extractor)
     return if request.nil?
+    return unless request_dispatched?(request)
 
     attributes = extractor.request_attributes(request, example)
     return if RSpec::OpenAPI.ignored_paths.any? { |ignored_path| attributes[:path].match?(ignored_path) }
@@ -20,6 +21,10 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
   end
 
   private
+
+  def request_dispatched?(request)
+    !request.path.to_s.empty?
+  end
 
   def select_request_response(context, example, extractor)
     pattern = RSpec::OpenAPI::ExchangeRecorder.pattern_for(example)

--- a/spec/requests/rails_controller_spec.rb
+++ b/spec/requests/rails_controller_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe TablesController, type: :controller do
     get :show, params: { id: 1 }
     expect(response).to have_http_status(:ok)
   end
+
+  it 'ignores an example that issues no request' do
+    expect(described_class).to eq(TablesController)
+  end
 end

--- a/spec/rspec/rails_config_variants_spec.rb
+++ b/spec/rspec/rails_config_variants_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'rails request spec, configuration variants' do
     it 'does not record a controller example that issued no request' do
       rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
       paths = YAML.safe_load(File.read(openapi_path)).fetch('paths').keys
+      expect(paths).not_to be_empty
       expect(paths).to all(start_with('/'))
     end
   end

--- a/spec/rspec/rails_config_variants_spec.rb
+++ b/spec/rspec/rails_config_variants_spec.rb
@@ -32,5 +32,11 @@ RSpec.describe 'rails request spec, configuration variants' do
       rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
       expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
     end
+
+    it 'does not record a controller example that issued no request' do
+      rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
+      paths = YAML.safe_load(File.read(openapi_path)).fetch('paths').keys
+      expect(paths).to all(start_with('/'))
+    end
   end
 end


### PR DESCRIPTION
## Problem

`RecordBuilder#build` already bails out when there is no request object (`return if request.nil?`). But a **controller spec** that asserts something without ever issuing its `subject` request still exposes a *blank* request — `request.path == ""`. That slips past the `nil?` guard, `find_rails_route` matches nothing, the Rails extractor falls back to the Rack extractor, and the example is recorded as an operation under an **empty path key** (`paths[""]`).

The result is an OpenAPI document that strict validators reject (in our case Orval, downstream). The producing test suite passes, so the invalid document isn't noticed until it's consumed elsewhere.

The integration-spec equivalent is already handled — a request spec that makes no request yields a `nil` request and is skipped (`spec/integration_tests/rails_test.rb` even tests it). Controller specs are the gap.

## Fix

Skip the example when no request was actually dispatched. A dispatched request always has a non-empty, `/`-prefixed path (the root is `/`), so a blank path is the reliable "nothing was issued" signal:

```ruby
return if request.nil?
return unless request_dispatched?(request)
```

The guard reads `request.path`, which every extractor (Rails, Rack, Hanami) already relies on, so it's extractor-agnostic and needs no per-extractor handling.

## Test

`spec/requests/rails_controller_spec.rb` gains a controller example that issues no request, and `spec/rspec/rails_config_variants_spec.rb` asserts the generated controller document keeps only `/`-prefixed path keys. Without the fix, that example records `paths[""]` and the assertion (and the committed-fixture comparison) fail; with it, the document is unchanged.


Fixes #434.
